### PR TITLE
Engine contract: engine-api.md, the ZayaBook facade and engine-agnostic contract tests (#21, step E1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Zaya are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **The engine's contract, written down (issue #21)**: `docs/engine-api.md` specifies everything the application asks of the page-turn engine — construction and its options, teardown and resizing, navigation and the page-mode and direction rules, the pdf.js document and the mapping between PDF pages and book pages, the search hooks, the side panels and their DOM contract, the render modes and `?render=`, sound and zoom, and the ordering of the `zaya:*` events. Every member is marked as part of the contract or as internal. It is written from the outside — from what the app asks for and what it must observe in return — so a clean-room engine can be written from it without reference to the current one.
+- **Contract tests**: `tests/engine-contract.spec.mjs` exercises every kept member through `ZayaBook` on the sample, outline and Arabic fixtures: navigation and page-change events, page-mode switching and the page mapping in both modes, right-to-left reading, teardown with no stage or canvas left behind, resizing, search highlights and their repaint, both render modes including `?render=css`, and the stiff-page option. The assertions are about behaviour rather than markup, so a replacement engine runs the same file unchanged.
+
+### Changed
+- **The application talks to the engine through one facade**: `lib/js/core/book.js` publishes `window.ZayaBook`, and every feature — the control bar and its More menu, the Navigator, print, the Text pane, URL options and the loader — now goes through it instead of reaching into `window.dFlipBook`, `window.flipbookInstance`, `DFLIP.activeBook`, `book.target`, `book.contentProvider` or `book.ui`. `lib/js/core/load.js` is the only caller that opens a book. Reading direction and page mode are named (`"ltr"`/`"rtl"`, `"single"`/`"double"`) rather than numbered, and a disposed book hands its container back unmarked instead of leaving a stage-shaped element behind.
+- Page turns are reported through the `onPageChanged` construction option rather than by the engine writing to page memory and `AppState` itself.
+- `window.dFlipBook` and `window.flipbookInstance` remain as deprecated aliases for one release, so plugins written against them keep working. Nothing in `lib/` reads them.
+
 ## [6.3.0] - 2026-09-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ npm run build:assets   # recompile Tailwind CSS and the changelog bundle (output
 ```
 
 Scripts are loaded and ordered by `lib/js/app.js` — there is nothing to include by hand in the HTML.
-See `docs/CONTRIBUTING.md`, `docs/SECURITY.md`, `docs/ARCHITECTURE.md` and `docs/DESIGN.md`.
+See `docs/CONTRIBUTING.md`, `docs/SECURITY.md`, `docs/ARCHITECTURE.md`, `docs/DESIGN.md` and
+`docs/engine-api.md` (the contract between the app and the page-turn engine).
 
 ## Roadmap
 
@@ -78,7 +79,10 @@ Open milestones, in the order they matter:
 - **Replace the flipbook engine** ([issue #21](https://github.com/ibra-kdbra/Zaya/issues/21)). The
   page-turn engine under `engine/` is a fork of DearFlip Lite and carries a non-commercial licence
   (see `docs/THIRD_PARTY_NOTICES.md`). A permissively-licensed replacement is the one change the
-  rest of the project waits on.
+  rest of the project waits on. The contract that replacement is to be written from is frozen in
+  `docs/engine-api.md`, the app reaches the engine only through `window.ZayaBook`
+  (`lib/js/core/book.js`), and `tests/engine-contract.spec.mjs` is the engine-agnostic suite the
+  replacement has to pass.
 - **Slice the app into `src/features`.** The first-party code under `lib/js` still follows the
   served layout rather than the shape of the features. Reorganising it is deferred until the engine
   is replaced, so that both moves land as one change of URL.
@@ -160,7 +164,8 @@ the control panel (Settings → Media Loop). The setting is remembered across se
             ├── style.css     the sheet that pulls the others together
         └── 📁images
         └── 📁js
-            └── 📁core        load.js — glue between the UI, AppState and the engine
+            └── 📁core        book.js — ZayaBook, the one facade over the engine
+            │                 load.js — glue between the UI, AppState and ZayaBook
             └── 📁features
                 └── 📁changelog
                     └── 📁services  ChangelogApiService.js, ChangelogParserService.js

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ everything below.
 | --- | --- | --- |
 | the top level | The served entry points and nothing else: `index.html`, `changelog.html`, `sw.js` (a service worker only controls pages at or below its own path, so it has to live here), `config.js` for per-deployment settings, plus the repository's own metadata. | MIT |
 | `lib/` | The first-party application: `lib/js/app.js` (the loader), `lib/js/core/load.js`, `lib/js/ui/`, `lib/js/features/`, `lib/js/utils/`, `lib/js/i18n/`, the stylesheets under `lib/css/`, and the images and sounds the app itself ships. | MIT |
-| `engine/` | The page-turn engine: a fork of DearFlip Lite, modularised into ES modules, with its own stylesheet as `engine/engine.css`. It is neither ours nor a library we merely use, which is why it has a root of its own — it is the one part of the tree we intend to delete. | CC BY-NC-ND 4.0, non-commercial only |
+| `engine/` | The page-turn engine: a fork of DearFlip Lite, modularised into ES modules, with its own stylesheet as `engine/engine.css`. It is neither ours nor a library we merely use, which is why it has a root of its own — it is the one part of the tree we intend to delete. Reached only through the facade below. | CC BY-NC-ND 4.0, non-commercial only |
 | `vendor/` | Third-party runtime code, unmodified but for the patches recorded in `THIRD_PARTY_NOTICES.md`: `vendor/js` (jQuery, three.js, pdf.js and its worker and CMaps, marked, Toastify, the engine's mockup build), `vendor/css`, `vendor/fonts` and `vendor/ocr` (Tesseract and its language packs). Each licence sits beside the files it covers. | various, all noted |
 
 Three roots are not served at all: `docs/` (these notes, contributing, security, design and the
@@ -26,10 +26,34 @@ Ask one question at a time, in this order:
    Content-Security-Policy.
 2. **Is it part of the page-turn engine?** Then `engine/`, and only if there is no way to do it
    from the outside. The engine is on its way out; every line added to it is a line to port later.
+   Whatever the answer, the new file does not talk to it directly — see the facade rule below.
 3. **Does the browser fetch it?** Then somewhere under `lib/` — `lib/js/features/<feature>/` for a
    feature, `lib/js/utils/` for something several features share, `lib/js/ui/` for the chrome,
    `lib/css/page/` for a stylesheet, and register it in the loader (below).
 4. **Otherwise** it is `docs/`, `tools/` or `tests/`, and it must not be reachable over HTTP.
+
+## The engine facade
+
+**Only `lib/js/core/book.js` may import, reference or otherwise know about `engine/`.** It
+publishes `window.ZayaBook`; everything else in `lib/` works through that and through nothing
+else. No other file may read `window.dFlipBook`, `window.flipbookInstance`, `DFLIP.activeBook`,
+or reach into a book's `target`, `contentProvider`, `ui`, `stage` or `options`.
+
+`docs/engine-api.md`, beside this file, is the contract `ZayaBook` publishes: it is written from
+the application's usage and the engine's observable behaviour rather than from the fork's
+internals, precisely so that a clean-room replacement can be written from it. Each member is
+marked as part of the contract or as internal. `tests/engine-contract.spec.mjs` exercises every
+kept member through `ZayaBook` alone and asserts behaviour rather than markup, so the same file
+runs against the replacement.
+
+Two consequences. Replacing the engine is a rewrite of one file under `lib/` plus whatever
+replaces `engine/` — not a pass over every feature. And a feature that finds itself wanting
+something the contract does not offer adds it to `ZayaBook` and to `engine-api.md`, rather than
+reaching past them; that addition is then a requirement on the replacement, so it is worth being
+sure it is needed.
+
+`window.dFlipBook` and `window.flipbookInstance` survive as deprecated aliases for one release,
+for plugins written before the facade existed. They are not for `lib/`.
 
 ## The ordered loader
 
@@ -41,8 +65,10 @@ fetches them in parallel and runs them in the order they were appended, in three
    `pdf.worker.min.js` is deliberately absent: pdf.js spawns it as a Web Worker itself, from the
    path the engine hands it.
 2. **Utilities, state, i18n and the engine** — `lib/js/utils/*`, the dictionaries, then
-   `engine/index.js`. Entries listed in the `MODULES` set are loaded as `type="module"`, which the
-   browser defers, so they run after the classic scripts of the same batch.
+   `engine/index.js` and `lib/js/core/book.js`. Entries listed in the `MODULES` set are loaded as
+   `type="module"`, which the browser defers, so they run after the classic scripts of the same
+   batch — which is why the facade, a classic script, may be listed after the engine and still run
+   before it: it only publishes `ZayaBook`, and looks the engine up when a book is opened.
 3. **The application** — `core/load.js`, the UI and every feature.
 
 Two consequences worth knowing. Everything is a global on `window` unless it is in `MODULES`;

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,7 +33,8 @@ file belongs. In short:
 | `index.html`, `changelog.html` | The two pages of the site |
 | `lib/js/app.js` | Ordered script loader (the only place load order is defined) |
 | `engine/` | The flipbook engine (modularised DearFlip 1.7.x fork, see licensing note below) |
-| `lib/js/core/load.js` | Glue between the UI, `AppState` and the flipbook |
+| `lib/js/core/book.js` | `window.ZayaBook`, the one facade over the engine — the only file in `lib/` allowed to touch it |
+| `lib/js/core/load.js` | Glue between the UI, `AppState` and the flipbook; the only caller of `ZayaBook.create` |
 | `lib/js/ui/`, `lib/js/features/` | Control panel, bottom bar, media, quotes, themes, changelog, search |
 | `lib/js/utils/` | State store, plugin registry, validation, service-worker manager |
 | `lib/css/` | Styles; theme tokens are CSS custom properties in `lib/css/themes/themes.css` |
@@ -41,7 +42,17 @@ file belongs. In short:
 | `sw.js` | Service worker (must stay at the site root) |
 | `tests/` | Playwright smoke tests |
 | `tools/` | Dev configuration and checks (eslint, playwright, tailwind, `check-syntax.mjs`, `check-version.mjs`) |
-| `docs/` | Architecture, contributing, security, design and third-party notes |
+| `docs/` | Architecture, contributing, security, design, the engine contract and third-party notes |
+
+## Talking to the flipbook
+
+Everything the app asks of the page-turn engine goes through `window.ZayaBook`, and
+`docs/engine-api.md` is the contract it publishes. Never read `window.dFlipBook`,
+`window.flipbookInstance` or `DFLIP.activeBook`, and never reach into a book's `target`,
+`contentProvider`, `ui` or `options`: those are the engine's insides, and the engine is being
+replaced. If the contract is missing something your feature needs, add it to
+`lib/js/core/book.js` and to `docs/engine-api.md` in the same change, and cover it in
+`tests/engine-contract.spec.mjs`.
 
 ## Plugin / extension API
 

--- a/docs/engine-api.md
+++ b/docs/engine-api.md
@@ -1,0 +1,291 @@
+# The engine contract
+
+Zaya draws its pages with an engine it does not own: the fork under `engine/`, derived from
+DearFlip Lite and licensed CC BY-NC-ND 4.0. Replacing it with permissively-licensed code is the
+one structural change the project is still waiting on, and this file is the specification that
+replacement is to be written from.
+
+It is written from the outside. Everything below is stated as *what the application asks for* and
+*what it must observe in return* — never as a description of how the fork happens to be built —
+so that an engine written against this page owes nothing to the fork's code or structure.
+
+Two files enforce it:
+
+- **`lib/js/core/book.js`** implements the contract as `window.ZayaBook`, today by delegating to
+  the fork. It is the only file under `lib/` allowed to know how the engine is put together.
+- **`tests/engine-contract.spec.mjs`** exercises every KEEP member through `window.ZayaBook` on
+  the fixtures. It asserts behaviour, not markup, so a replacement engine runs the same file.
+
+Each member is marked **KEEP** (part of the contract; the app may rely on it) or **INTERNAL**
+(the app must not touch it; listed here so that what was migrated away is on the record).
+
+---
+
+## 1. The namespace
+
+`window.ZayaBook` is a classic script, listed in `lib/js/app.js` straight after the engine. It
+publishes the namespace only; the engine itself is looked up when a document is opened.
+
+| Member | Signature | Semantics | Used by | |
+| --- | --- | --- | --- | --- |
+| `create` | `(container, source, options) → Handle` | Opens `source` inside `container` (an element or a selector) and returns a handle. The handle also becomes `ZayaBook.current`. Throws synchronously if the container does not exist or the engine has not loaded. **`lib/js/core/load.js` is the only caller.** | `core/load.js` | KEEP |
+| `current` | getter → `Handle \| null` | The open document, or `null` when none is open. Reading it is cheap and safe at any time, including before the first load and after a teardown. | every feature | KEEP |
+| `isReady` | getter → `boolean` | True while a document is open *and* its pages can be turned. `current` may be non-null a moment before this becomes true. | `tests/helpers.mjs`, `core/load.js` | KEEP |
+| `dispose` | `() → void` | Tears down `current`, if any. Equivalent to `current.dispose()`. | — | KEEP |
+| `stageSelector` | `string` | A CSS selector matching the stage element(s) of an open book, and nothing when none is open. It exists so that a leak check — which has no API left to ask — can stay engine-agnostic; a replacement engine names its own root class here. | `tests/engine-contract.spec.mjs` | KEEP |
+
+### Construction options
+
+`create` takes exactly the options below. Anything else is passed through untouched, so a
+replacement engine may accept more, but must not *require* more.
+
+| Option | Type | Meaning | KEEP |
+| --- | --- | --- | --- |
+| `height` | `string \| number` | The stage height. Zaya passes `"100%"`; a bare number is pixels. | KEEP |
+| `paddingTop` | `number` | Pixels kept clear at the top of the stage, so the app header does not sit over the page. Zaya passes `56`. | KEEP |
+| `paddingBottom` | `number` | Pixels kept clear at the bottom, for the control bar. Zaya passes `40`. | KEEP |
+| `duration` | `number` | Milliseconds one page turn takes. Zaya passes `700`. | KEEP |
+| `backgroundColor` | CSS colour | The colour behind the book. | KEEP |
+| `direction` | `"ltr" \| "rtl"` | Reading direction, fixed for the life of the book: changing it reopens the document (§3). | KEEP |
+| `openPage` | `number` | The book page to open on, 1-based. Out-of-range values are clamped, never rejected. | KEEP |
+| `pdfId` | `string` | The key page memory and notes are filed under. Opaque to the engine; it only hands it back with page changes. | KEEP |
+| `hard` | `"none" \| "cover" \| "all"` | How many sheets are stiff: none, the outer cover only, or every sheet. Load-time only (§8). | KEEP |
+| `soundEnable` | `boolean` | Whether a page turn makes a sound. May be changed later through `setSoundEnabled` (§7). | KEEP |
+| `text` | `object` | The engine's own labels, already translated: `toggleSound`, `toggleThumbnails`, `toggleOutline`, `previousPage`, `nextPage`, `toggleFullscreen`, `zoomIn`, `zoomOut`, `toggleHelp`, `singlePageMode`, `doublePageMode`, `downloadPDFFile`, `gotoFirstPage`, `gotoLastPage`, `play`, `pause`, `share`, `mailSubject`, `mailBody`, `loading`. Missing keys fall back to the engine's own wording. Built by `engineText()` in `core/load.js` from the `engine.*` i18n keys. | KEEP |
+| `onReady` | `(handle) => void` | Called once, when the document is open and its first spread has been laid out. Receives the **handle**, never an engine object. | KEEP |
+| `onPageChanged` | `(bookPage) => void` | Called on every page turn, with the book page now open. The facade wraps this to write page memory and `AppState`, so a replacement engine needs to know nothing about either. | KEEP |
+| `zoomChange` | `(isZoomed) => void` | Called when the reader zooms in or back out. Zaya uses it to stop the document scrolling behind a zoomed page. | KEEP |
+
+Options the fork also reads — `webgl`, `pageMode`, `singlePageMode`, `pageSize`, `transparent`,
+`forceFit`, `autoPlay`, `search`, `icons`, `mockupjsSrc`, `pdfjsSrc`, `soundFile`,
+`imagesLocation`, `cMapUrl`, `enableDownload`, `controlsPosition` — are **INTERNAL**: Zaya passes
+none of them, and a replacement engine owes nothing for them. Asset locations in particular are
+the engine's own business; the fork resolves them from its module URL and nothing in `lib/`
+supplies them.
+
+---
+
+## 2. Lifecycle
+
+| Member | Signature | Semantics | Used by | |
+| --- | --- | --- | --- | --- |
+| `dispose()` | `() → void` | Closes the document: stops rendering, releases the PDF, removes every element the engine added to the container, and hands the container element back unmarked — no leftover classes, no leftover inline sizing. Calling it twice is a no-op. Afterwards the handle answers quietly (`activePage` 1, `pageCount` 0, `pdfDocument` null, `isReady()` false, `disposed` true) rather than throwing, and `ZayaBook.current` is `null`. | `core/load.js`, `utils/memory-manager.js` | KEEP |
+| `disposed` | getter → `boolean` | Whether this handle has been torn down. | contract tests | KEEP |
+| `resize()` | `() → void` | Re-measure the stage and re-lay the book. Called after anything changes the size of the reading area: a docked drawer opening, a fullscreen change. Safe to call before the document is ready and after it is disposed. | `core/load.js`, `features/controls/` | KEEP |
+| `isReady()` | `() → boolean` | Whether pages can be turned yet. | `tests/helpers.mjs` | KEEP |
+| `source` | getter → `string \| null` | The source the book was opened with, as given. `null` once disposed. | `core/load.js` | KEEP |
+| `createdWith` | getter → `object \| null` | The options `create` was given, for a handle that `create` made; `null` for a book adopted from elsewhere. | contract tests | KEEP |
+| `engine` | getter | The underlying engine object. **INTERNAL** — it exists for `core/book.js` itself and its tests; nothing else in `lib/` may read it. | — | INTERNAL |
+
+**No leaks.** After `dispose()` — and after opening a second document — the page must hold exactly
+one stage (`ZayaBook.stageSelector`) for one open book and none for none, and no canvases left
+under `#flipbookContainer`. The contract test opens four documents in a row and checks this after
+each.
+
+---
+
+## 3. Navigation
+
+Book pages are 1-based and count *faces*, not sheets: a three-page PDF is three book pages,
+whether the reader sees them one at a time or as spreads.
+
+| Member | Signature | Semantics | Used by | |
+| --- | --- | --- | --- | --- |
+| `activePage` | getter → `number` | The page now open — the left-hand page of the spread in double mode. `1` before anything is open. | control bar, print, text pane, page memory | KEEP |
+| `pageCount` | getter → `number` | Book pages in the document. `0` when none is open. | control bar, print, search panel | KEEP |
+| `gotoPage(n)` | `(number) → number` | Turn to page `n`, animating. `n` is clamped into `1…pageCount`; a non-number is treated as `1`. Returns the page the book is on when the call returns (the animation may still be running). | control bar, search results, tests | KEEP |
+| `next()` | `() → void` | Turn one page (one spread in double mode) forward *in reading order*: leftward in a right-to-left book. No-op at the end. | control bar | KEEP |
+| `prev()` | `() → void` | The same, backwards. No-op at the start. | control bar | KEEP |
+| `first()` | `() → void` | Turn to the first page. | More menu | KEEP |
+| `last()` | `() → void` | Turn to the last page. | More menu | KEEP |
+| `pageMode` | getter → `"single" \| "double"` | Whether one page or a spread is on screen. | control bar, print, text pane, URL options | KEEP |
+| `setPageMode(isSingle, fromUser)` | `(boolean, boolean) → "single" \| "double"` | Switch layout. `fromUser` marks the choice as the reader's own, so the engine's own viewport heuristic must not override it afterwards. Returns the mode in force. Re-lays the book and keeps the reader on the page they were on. | More menu, `?mode=`, remembered prefs | KEEP |
+| `direction` | getter → `"ltr" \| "rtl"` | Reading direction. **Read-only:** direction is fixed at construction, so the app changes it by disposing the book and calling `create` again with the new `direction` and the same `openPage` (see `reopenOnSamePage` in `core/load.js`). | `core/load.js` | KEEP |
+
+Turning a page must call `options.onPageChanged(bookPage)` — once per settled page, not once per
+animation frame. `AppState` turns that into the `zaya:pageChanged` event (§9).
+
+**INTERNAL, migrated away:** `book.target.gotoPage`, `book.target.next`, `book.target.prev`,
+`book.target._activePage`, `book.target.pageCount`, `book.target.pageMode`,
+`book.target.direction`, `book.start()`, `book.end()`, and the numeric direction and page-mode
+codes (`1`/`2`). These were read directly by `core/load.js`, `features/controls/custom-controls.js`,
+`features/print/print.js`, `features/text/text-pane.js`, `utils/url-options.js` and
+`tests/helpers.mjs`; all now go through the members above.
+
+---
+
+## 4. The document
+
+| Member | Signature | Semantics | Used by | |
+| --- | --- | --- | --- | --- |
+| `pdfDocument` | getter → `PDFDocumentProxy \| null` | The pdf.js document proxy for the open PDF, so the app can render pages itself. Zaya prints from it (`features/print/print.js`) and indexes its text for search and the Text pane. `null` before the document is open and after teardown. The engine owns the proxy's lifetime: it must stay usable until `dispose()`. | print, search, text pane | KEEP |
+| `spreadPerPdfPage` | getter → `boolean` | Whether one PDF page carries a whole two-page spread — a scanned booklet, where the page count of the book is roughly twice the page count of the PDF. | text pane, print | KEEP |
+| `toPdfPage(bookPage)` | `(number) → number` | Book page → PDF page. Identity for an ordinary document. When `spreadPerPdfPage`, book pages 1 and 2 are the covers on PDF pages 1 and 2, and from book page 3 on each PDF page carries two: `ceil((bookPage − 1) / 2) + 1`. Always returns at least `1` and never more than `pdfDocument.numPages`. | text pane, print | KEEP |
+| `toBookPage(pdfPage)` | `(number) → number` | The inverse: identity for an ordinary document, `pdfPage * 2 − 1` beyond PDF page 2 when `spreadPerPdfPage`. Clamped into `1…pageCount`. | search results | KEEP |
+| `visiblePdfPages()` | `() → number[]` | The PDF pages on screen right now, in reading order, with duplicates removed: one page in single mode, the pair of the spread in double mode (the even page and the odd one after it), mapped through `toPdfPage`. Empty before the document is ready. | text pane | KEEP |
+
+Both mappings are total functions: they never throw and never leave the document, whatever number
+— zero, negative, fractional, past the end — they are handed.
+
+**INTERNAL, migrated away:** `book.contentProvider.pdfDocument`, `book.contentProvider.pageCount`,
+`book.contentProvider.options.pageSize`.
+
+---
+
+## 5. Search
+
+Zaya indexes the text itself (`lib/js/features/search/`) and can recognise pages that carry no
+text layer. What the engine owes is the drawer element the panel lives in, and the ability to
+paint marks into the page as it is rendered — marks live in the page texture, so they show
+identically in whichever renderer is running.
+
+| Member | Signature | Semantics | Used by | |
+| --- | --- | --- | --- | --- |
+| `searchController` | getter → `PdfTextSearch \| null` | The index, once built. `null` until `ensureSearch()` or the search panel has been asked for. | text pane, tests | KEEP |
+| `ensureSearch()` | `() → PdfTextSearch \| null` | Build the search panel and its index if they do not exist yet, and return the controller. Idempotent: calling it repeatedly returns the same controller and builds nothing twice. `null` for a document that has no text to index. | text pane | KEEP |
+| `setSearchHighlight(query)` | `(string) → void` | Set the query whose hits are painted onto the pages, or clear it with `""`. A query shorter than two characters counts as cleared. Repaints whatever is visible. | search panel | KEEP |
+| `drawSearchHighlights(ctx, viewport, pdfPage)` | `(CanvasRenderingContext2D, PageViewport, number) → boolean` | Paint the current query's hits for `pdfPage` onto any 2D context, using the pdf.js viewport to place them. Returns whether anything was drawn — `false` when no query is set or the page has no hits. The app calls this when it renders a page itself, so a printed sheet carries the same marks as the screen. | print | KEEP |
+| `refreshVisiblePages()` | `() → void` | Re-render the pages on screen. Called when newly recognised text means the marks have changed under the reader. | search panel, text pane | KEEP |
+| `searchInput()` | `() → HTMLInputElement \| null` | The search field, so the app can focus it or read it back. | text pane, URL options | KEEP |
+| `openSearch(query)` | `(string?) → void` | Open the search panel and, with a query, fill the field and start the search. Called by `?search=` and by "Search this selection" in the Text pane. | `?search=`, text pane | KEEP |
+
+**INTERNAL, migrated away:** `book.contentProvider.searchController`,
+`book.contentProvider.initSearch`, `book.contentProvider.setSearchHighlight`,
+`book.contentProvider.drawSearchHighlights`, `book.contentProvider.refreshVisiblePages`,
+`book.target.searchInput`, `book.target.searchContainer`, `book.ui.searchPanel`.
+
+---
+
+## 6. Panels
+
+The engine builds three side panels — thumbnails, outline and search — because they need the
+stage to suppress orbiting and scrolling while the pointer is over them. Zaya's Navigator
+(`features/controls/custom-controls.js`) re-parents them into its own drawer as tabs; the Text
+pane beside them is Zaya's own and no concern of the engine's.
+
+| Member | Signature | Semantics | Used by | |
+| --- | --- | --- | --- | --- |
+| `ensurePanel(name)` | `("thumbs"\|"outline"\|"search") → Element \| null` | Build the panel if it does not exist, and return its root element. Idempotent — a second call builds nothing. `null` for an unknown name, and for a panel the document cannot support (no outline, no text). | Navigator | KEEP |
+| `panel(name)` | `("thumbs"\|"outline"\|"search") → Element \| null` | The panel's root element if it has been built, else `null`. | Navigator | KEEP |
+| `setPanelActive(name, on)` | `(string, boolean) → void` | Tell the engine's own toolbar which panel the app considers open, so its buttons agree with the drawer. Silently does nothing for an unknown name. | Navigator | KEEP |
+| `updateUi(force)` | `(boolean?) → void` | Redraw the engine's own chrome — page numbers, button states — after the app has changed something behind its back. `force` redraws even when nothing looks changed. | Navigator, `core/load.js` | KEEP |
+
+### The DOM contract
+
+A panel root must be an element that:
+
+- carries `df-sidemenu`, and `df-sidemenu-visible` exactly while it is showing. The Navigator
+  toggles that second class to open and close a tab, and watches it so that a panel the engine
+  opens by itself (`?search=`, the engine's own toolbar) opens the drawer too;
+- survives being moved into another parent. The Navigator appends it to `#navigatorBody` and
+  gives it an id (`navPaneThumbs` / `navPaneOutline` / `navPaneSearch`), `role="tabpanel"`,
+  `tabindex` and `data-nav-tab`; the engine must not move it back or re-create it in place;
+- is rebuilt per document, and the old one discarded. Exactly one of each kind may exist.
+
+The Navigator recognises panels, and decides whether one is empty, by these class names. They are
+part of the contract until the panels are rebuilt as Zaya's own, and a replacement engine must
+produce them:
+
+| Selector | What it marks |
+| --- | --- |
+| `.df-thumb-container` | the thumbnails panel root |
+| `.df-vrow` | one thumbnail row inside it |
+| `.df-outline-container` | the outline panel root |
+| `.df-outline-item` | one outline entry |
+| `.df-search-container` | the search panel root, which the app fills |
+| `.df-sidemenu`, `.df-sidemenu-visible` | any panel, and the one showing |
+
+Also styled by the app or queried by tests, and so equally part of the DOM contract:
+`.df-container` (the stage root, on `#flipbookContainer` itself), `.df-book-page`,
+`.df-book-stage`, `.df-book-wrapper`, `.df-css-page`, `.df-page-front`, `.df-page-back`,
+`.df-ui` and its buttons (`.df-ui-btn`, `.df-ui-page`, `.df-ui-download`, `.df-ui-controls`),
+`.df-next-button` / `.df-prev-button`, `.df-share-*`, `.df-fullscreen-active`, `.df-rtl`.
+A replacement engine is free to rename all of these, provided it renames them in
+`lib/css/page/shell.css`, `custom-ui.css` and `chrome.css`, in the Navigator's selector table and
+in `ZayaBook.stageSelector` at the same time. The contract tests do not depend on them.
+
+The search panel's own contents (`.df-search-input`, `.df-search-result`, `.df-search-status`,
+`.df-ocr*`) are built by `lib/js/features/search/search-panel.js` and are **not** the engine's.
+
+**INTERNAL, migrated away:** `book.contentProvider.initThumbs`,
+`book.contentProvider.initOutline`, `book.ui.thumbnail`, `book.ui.outline`, `book.ui.update`.
+
+---
+
+## 7. Chrome, sound and zoom
+
+| Member | Signature | Semantics | Used by | |
+| --- | --- | --- | --- | --- |
+| `toggleFullscreen()` | `() → void` | Enter or leave fullscreen, through whatever mechanism the engine uses, so its own stage follows. | control bar | KEEP |
+| `share()` | `() → void` | Open the engine's share box for the current page. | control bar | KEEP |
+| `download()` | `() → boolean` | Offer the open document for download. Returns whether anything happened; falls back to opening `source` in a new tab when the engine has no download control of its own. | More menu | KEEP |
+| `zoom(delta)` | `(number) → void` | Zoom in (`+1`) or out (`−1`) one step. Zooming past the fit-to-page step calls the `zoomChange` option. | control bar | KEEP |
+| `setInteractive(on)` | `(boolean) → void` | Let the stage go, or take it back. The app switches this off while the pointer is over a drawer, so dragging in a panel does not orbit the book beneath it, and back on when the pointer leaves. A renderer with nothing to orbit may ignore it. | control bar | KEEP |
+| `interactive` | getter → `boolean` | Whether the stage is currently taking pointer input. A renderer with nothing to orbit reports `true`. | contract tests | KEEP |
+| `soundEnabled` | getter → `boolean` | Whether page turns make a sound. Defaults to the `soundEnable` option, `true` when unset. | More menu | KEEP |
+| `setSoundEnabled(on)` | `(boolean) → void` | Turn the page-turn sound on or off, and update whatever the engine shows for it. The app remembers the choice itself (`zayaSoundEnabled`) and re-applies it to each new book, because the engine forgets it between documents. | More menu | KEEP |
+
+**INTERNAL, migrated away:** `book.ui.switchFullscreen`, `book.ui.share`, `book.ui.download`,
+`book.ui.updateSound`, `book.options.soundEnable`, `book.options.source`,
+`book.stage.orbitControl.enabled`.
+
+---
+
+## 8. Render modes and stiff pages
+
+**`renderMode`** — getter → `"webgl" | "css"`, **KEEP**. Which renderer is drawing: the 3D one, or
+the 2D fallback for machines whose WebGL is missing or unusable. The app does not choose it;
+it reports it (issue #22), and every other member of this contract behaves identically in both.
+
+The renderer can be pinned, for a browser with broken WebGL and for testing:
+
+- `window.ZAYA_RENDER_MODE = "css" | "webgl"` — set by the page, wins over everything;
+- `?render=css` (also `2d`, `html`) or `?render=webgl` (also `3d`) — read at construction.
+
+Anything else leaves the choice to whether WebGL works. The value is documented in
+`lib/js/utils/url-options.js` and read by the engine when the book is built, not by the app.
+
+**`hardCover`** — getter → `"none" | "cover" | "all"`, **KEEP**. Which sheets are stiff, as passed
+in the `hard` option. It is a **load-time** option in both renderers: changing it means disposing
+the book and calling `create` again on the same page, which is what
+`window.appState.subscribe('hardCover', …)` in `core/load.js` does. The getter exists so the app
+can tell what the open book was given.
+
+---
+
+## 9. Events
+
+Four events are dispatched on `document`. **None of them is the engine's** — this is the boundary
+the facade draws, and a replacement engine dispatches nothing at all. They are listed because
+they are the contract's observable side and the plugin API's (`docs/CONTRIBUTING.md`).
+
+| Event | Dispatched by | Detail | When |
+| --- | --- | --- | --- |
+| `zaya:init` | `lib/js/app.js` | `{ version }` | Once, after every script has loaded and run. Everything on `window` exists by now, so restoring drawers and applying `?theme=` / `?lang=` waits for it. |
+| `zaya:toolbarReady` | `lib/js/ui/controls.js` | — | When the app's own chrome is wired. Fires while `controls.js` is running, i.e. **before** `zaya:init`. |
+| `zaya:pdfLoaded` | `lib/js/utils/app-state.js` | `{ url, type, name }` | When the open document changes, driven by `core/load.js` calling `appState.updatePdfContext()`. Fires per document, not per render. |
+| `zaya:pageChanged` | `lib/js/utils/app-state.js` | `{ page }` | When the page settles on a new one, driven by the `onPageChanged` construction option through `appState.setLastPage()`. Turning to the page already open fires nothing. |
+
+Ordering over one document's life: `zaya:toolbarReady` → `zaya:init` → `zaya:pdfLoaded` →
+`zaya:pageChanged` (repeatedly). A second document repeats the last two. `onReady` fires between
+`zaya:pdfLoaded` and the first `zaya:pageChanged`.
+
+Zaya also emits `zaya:themeChanged`, `zaya:languageChanged`, `zaya:pageTextChanged`,
+`zaya:quotesChanged` and `zaya:recentChanged`; none has anything to do with the engine.
+
+---
+
+## 10. What the engine may not do
+
+The fork still reaches out of its own root in four places. Three are contract violations that a
+replacement engine must not repeat; the fourth is allowed.
+
+| Site | What it does | Verdict |
+| --- | --- | --- |
+| `engine/factory.js` | reports page turns through `options.onPageChanged` | **allowed** — that is the contract hook |
+| `engine/factory.js` | falls back to `window.saveLastPage` / `window.appState` when no `onPageChanged` is given | INTERNAL, for books opened by the engine's own lightbox; a replacement engine drops it |
+| `engine/ui/ui.js` | calls `window.ZayaNavigator.close()` | INTERNAL — a replacement engine reports the dismissal and lets the app decide |
+| `engine/core/texture-library.js` | calls `window.ZayaDocumentError()` on a failed load, and `window.ZayaCurrentDocKey()` for the search panel's storage key | INTERNAL — both belong in construction options or a failure callback |
+
+Untangling those three is step E2. They are recorded here so the replacement is not written
+against them by accident.

--- a/engine/factory.js
+++ b/engine/factory.js
@@ -171,8 +171,7 @@ export class FlipBook extends PreviewObject {
               if (self.ui) self.ui.update();
               self.checkCenter();
               self.stage.renderRequestPending = true;
-              if (window.saveLastPage) window.saveLastPage(options.pdfId, currentPage);
-              if (window.appState && window.appState.setLastPage) window.appState.setLastPage(currentPage);
+              reportPageChange(options, currentPage);
             };
 
             const $divLeft = $(self.stage.cssScene.divLeft.element);
@@ -234,8 +233,7 @@ export class FlipBook extends PreviewObject {
             const currentPage = self.target._activePage;
             if (self.ui) self.ui.update();
             self.checkCenter();
-            if (window.saveLastPage) window.saveLastPage(options.pdfId, currentPage);
-            if (window.appState && window.appState.setLastPage) window.appState.setLastPage(currentPage);
+            reportPageChange(options, currentPage);
           };
 
           self.target.resize = () => self.resize();
@@ -294,6 +292,22 @@ export class FlipBook extends PreviewObject {
   prev() {
     if (this.target && this.target.prev) this.target.prev();
   }
+}
+
+/**
+ * Announce a page turn. `options.onPageChanged` is the contract hook (see `docs/engine-api.md`);
+ * `lib/js/core/book.js` supplies it and does the remembering. A book opened without the facade --
+ * the engine's own lightbox -- still falls back to the globals it always used.
+ * @param {object} options the book's options
+ * @param {number} page    the book page now open
+ */
+function reportPageChange(options, page) {
+  if (typeof options.onPageChanged === "function") {
+    options.onPageChanged(page);
+    return;
+  }
+  if (window.saveLastPage) window.saveLastPage(options.pdfId, page);
+  if (window.appState && window.appState.setLastPage) window.appState.setLastPage(page);
 }
 
 // Helper to maintain original DFLIP.isBookletMode check

--- a/lib/js/app.js
+++ b/lib/js/app.js
@@ -87,7 +87,9 @@ async function loadApplication() {
             'lib/js/utils/pageMemory.js',
             'lib/js/utils/local-docs.js',
             'lib/js/utils/a11y.js',
-            'engine/index.js'
+            'engine/index.js',
+            // The one facade over the engine; nothing else in lib/ may touch it (docs/engine-api.md)
+            'lib/js/core/book.js'
         ]);
 
         await loadInOrder([

--- a/lib/js/core/book.js
+++ b/lib/js/core/book.js
@@ -1,0 +1,377 @@
+/*
+ * ZayaBook -- the one door between the application and the page-turn engine.
+ *
+ * Everything the app needs from a flipbook goes through `window.ZayaBook`. The contract it
+ * publishes is written down, engine-free, in `docs/engine-api.md`, and
+ * `tests/engine-contract.spec.mjs` exercises it end to end. This file is the only place in `lib/`
+ * that is allowed to know how the engine under `engine/` is put together: it translates the
+ * contract into that engine's shapes (`window.dFlipBook`, `book.target`, `book.contentProvider`,
+ * `book.ui`) and nothing else may.
+ *
+ * Replacing the engine therefore means rewriting this one file and leaving the rest of `lib/`
+ * untouched.
+ *
+ * Classic script, listed straight after `engine/index.js` in `lib/js/app.js`. It only publishes
+ * the namespace, so running before the deferred engine module does no harm: the engine is looked
+ * up when a document is opened, not when this file is evaluated.
+ */
+(function () {
+    "use strict";
+
+    /* The engine's own numbering, kept behind this boundary. */
+    const ENGINE_LTR = 1;
+    const ENGINE_RTL = 2;
+    const ENGINE_SINGLE = 1;
+    const ENGINE_DOUBLE_INTERNAL = 2;   // options.pageSize: one PDF page carries a whole spread
+
+    const PANELS = {
+        thumbs: { init: "initThumbs", selector: ".df-thumb-container", ui: "thumbnail" },
+        outline: { init: "initOutline", selector: ".df-outline-container", ui: "outline" },
+        search: { init: "initSearch", selector: ".df-search-container", ui: "searchPanel" }
+    };
+
+    /** Unwrap whatever the engine hands back: a jQuery set, a node list, or a plain element. */
+    function node(value) {
+        if (!value) return null;
+        if (value.nodeType === 1) return value;
+        return value[0] && value[0].nodeType === 1 ? value[0] : null;
+    }
+
+    function call(owner, name, args) {
+        if (!owner || typeof owner[name] !== "function") return undefined;
+        try { return owner[name].apply(owner, args || []); } catch (e) { return undefined; }
+    }
+
+    /**
+     * A live handle on one open document. Every getter reads the engine at the moment it is
+     * asked, so a handle stays correct while the engine rebuilds its stage, and reports the
+     * quiet defaults (`null`, `0`, `1`) once the book has been disposed.
+     */
+    function Handle(instance, created) {
+        const self = this;
+        let engine = instance;
+        let disposed = false;
+
+        const book = () => (disposed ? null : engine);
+        const target = () => { const b = book(); return (b && b.target) || null; };
+        const provider = () => { const b = book(); return (b && b.contentProvider) || null; };
+        const ui = () => { const b = book(); return (b && b.ui) || null; };
+
+        /* -------------------------------------------------------------- identity */
+
+        Object.defineProperty(self, "source", { get: () => { const b = book(); return (b && b.options && b.options.source) || null; } });
+        Object.defineProperty(self, "renderMode", { get: () => { const b = book(); return (b && b.renderMode) || null; } });
+        Object.defineProperty(self, "hardCover", { get: () => { const b = book(); return (b && b.options && b.options.hard) || "none"; } });
+        Object.defineProperty(self, "createdWith", { get: () => created });
+
+        self.isReady = () => !!target();
+
+        /* ------------------------------------------------------------ navigation */
+
+        Object.defineProperty(self, "activePage", {
+            get: () => { const t = target(); return (t && t._activePage) || 1; }
+        });
+        Object.defineProperty(self, "pageCount", {
+            get: () => {
+                const t = target();
+                const cp = provider();
+                return (t && t.pageCount) || (cp && cp.pageCount) || 0;
+            }
+        });
+        Object.defineProperty(self, "pageMode", {
+            get: () => { const t = target(); return t && t.pageMode === ENGINE_SINGLE ? "single" : "double"; }
+        });
+        Object.defineProperty(self, "direction", {
+            get: () => {
+                const b = book();
+                const t = target();
+                const value = (b && b.direction) || (t && t.direction) || ENGINE_LTR;
+                return value === ENGINE_RTL ? "rtl" : "ltr";
+            }
+        });
+
+        self.gotoPage = (n) => {
+            const wanted = Number(n) || 1;
+            const total = self.pageCount;
+            const page = Math.max(1, total ? Math.min(total, wanted) : wanted);
+            const t = target();
+            if (t && t.gotoPage) call(t, "gotoPage", [page]);
+            else call(book(), "gotoPage", [page]);
+            return self.activePage;
+        };
+        self.next = () => { const t = target(); if (t && t.next) call(t, "next"); else call(book(), "next"); };
+        self.prev = () => { const t = target(); if (t && t.prev) call(t, "prev"); else call(book(), "prev"); };
+        self.first = () => { call(book(), "start"); };
+        self.last = () => { call(book(), "end"); };
+
+        self.setPageMode = (isSingle, fromUser) => {
+            call(book(), "setPageMode", [!!isSingle, !!fromUser]);
+            return self.pageMode;
+        };
+
+        /* -------------------------------------------------------------- document */
+
+        Object.defineProperty(self, "pdfDocument", { get: () => { const cp = provider(); return (cp && cp.pdfDocument) || null; } });
+
+        /** Whether one PDF page carries a whole two-page spread (a scanned booklet). */
+        const doubleInternal = () => {
+            const cp = provider();
+            return !!(cp && cp.options && cp.options.pageSize === ENGINE_DOUBLE_INTERNAL);
+        };
+        Object.defineProperty(self, "spreadPerPdfPage", { get: doubleInternal });
+
+        self.toBookPage = (pdfPage) => {
+            let page = Math.max(1, Math.round(Number(pdfPage) || 1));
+            if (doubleInternal() && page > 2) page = page * 2 - 1;
+            const total = self.pageCount;
+            return Math.max(1, total ? Math.min(page, total) : page);
+        };
+        self.toPdfPage = (bookPage) => {
+            const page = Math.max(1, Math.round(Number(bookPage) || 1));
+            if (doubleInternal() && page > 2) return Math.ceil((page - 1) / 2) + 1;
+            const doc = self.pdfDocument;
+            return doc && doc.numPages ? Math.min(page, doc.numPages) : page;
+        };
+
+        /** The PDF pages on screen: one in single mode, the pair of the spread in double mode. */
+        self.visiblePdfPages = () => {
+            if (!self.isReady()) return [];
+            const total = self.pageCount || 1;
+            const active = Math.max(1, Math.min(total, self.activePage));
+            let pages = [active];
+            if (self.pageMode !== "single") {
+                const base = Math.floor(active / 2) * 2;
+                pages = [base, base + 1];
+            }
+            const out = [];
+            pages.forEach((p) => {
+                if (p < 1 || p > total) return;
+                const pdf = self.toPdfPage(p);
+                if (out.indexOf(pdf) === -1) out.push(pdf);
+            });
+            return out;
+        };
+
+        /* ---------------------------------------------------------------- search */
+
+        Object.defineProperty(self, "searchController", { get: () => { const cp = provider(); return (cp && cp.searchController) || null; } });
+
+        self.ensureSearch = () => {
+            const cp = provider();
+            if (!cp) return null;
+            if (!cp.searchController) call(cp, "initSearch");
+            return cp.searchController || null;
+        };
+        self.setSearchHighlight = (query) => { call(provider(), "setSearchHighlight", [query || ""]); };
+        self.drawSearchHighlights = (ctx, viewport, pdfPage) => !!call(provider(), "drawSearchHighlights", [ctx, viewport, pdfPage]);
+        self.refreshVisiblePages = () => { call(provider(), "refreshVisiblePages"); };
+
+        /* ---------------------------------------------------------------- panels */
+
+        self.panel = (name) => {
+            const spec = PANELS[name];
+            return spec ? document.querySelector(spec.selector) : null;
+        };
+        self.ensurePanel = (name) => {
+            const spec = PANELS[name];
+            const cp = provider();
+            if (!spec || !cp) return null;
+            if (!self.panel(name)) call(cp, spec.init);
+            return self.panel(name);
+        };
+        self.setPanelActive = (name, on) => {
+            const spec = PANELS[name];
+            const chrome = ui();
+            const el = spec && chrome ? node(chrome[spec.ui]) : null;
+            if (el) el.classList.toggle("df-active", !!on);
+        };
+        self.searchInput = () => {
+            const t = target();
+            return node(t && t.searchInput) || document.querySelector(".df-search-input");
+        };
+        self.openSearch = (query) => {
+            self.ensurePanel("search");
+            const chrome = ui();
+            const opener = chrome ? node(chrome.searchPanel) : null;
+            const panel = self.panel("search");
+            if (opener && !(panel && panel.classList.contains("df-sidemenu-visible"))) opener.click();
+            if (query == null) return;
+            const input = self.searchInput();
+            if (!input) return;
+            input.value = query;
+            input.dispatchEvent(new Event("input", { bubbles: true }));
+        };
+
+        /* ------------------------------------------------------- chrome and view */
+
+        self.updateUi = (force) => { call(ui(), "update", [force]); };
+        self.toggleFullscreen = () => { call(ui(), "switchFullscreen"); };
+        self.share = () => { const chrome = ui(); const el = chrome ? node(chrome.share) : null; if (el) el.click(); };
+        self.download = () => {
+            const chrome = ui();
+            const el = chrome ? node(chrome.download) : null;
+            if (el) { el.click(); return true; }
+            const src = String(self.source || "");
+            if (/^(https?:|blob:)/i.test(src)) { window.open(src, "_blank", "noopener"); return true; }
+            return false;
+        };
+        self.zoom = (delta) => { call(book(), "zoom", [delta]); };
+        self.resize = () => { call(book(), "resize"); };
+        /** Let go of the stage while the pointer is over app chrome that sits above it. */
+        self.setInteractive = (on) => {
+            const b = book();
+            if (b && b.stage && b.stage.orbitControl) b.stage.orbitControl.enabled = !!on;
+        };
+        Object.defineProperty(self, "interactive", {
+            get: () => {
+                const b = book();
+                if (!b || !b.stage || !b.stage.orbitControl) return true;
+                return !!b.stage.orbitControl.enabled;
+            }
+        });
+
+        /* ----------------------------------------------------------------- sound */
+
+        Object.defineProperty(self, "soundEnabled", {
+            get: () => {
+                const b = book();
+                const value = b && b.options ? b.options.soundEnable : true;
+                return !(value === false || value === "false");
+            }
+        });
+        self.setSoundEnabled = (on) => {
+            const b = book();
+            if (!b || !b.options) return;
+            b.options.soundEnable = !!on;
+            call(ui(), "updateSound");
+        };
+
+        /* ------------------------------------------------------------- lifecycle */
+
+        self.dispose = () => {
+            if (disposed) return;
+            const b = engine;
+            const host = b ? node(b.container) : null;
+            disposed = true;
+            if (b) {
+                if (typeof b.dispose === "function") { try { b.dispose(); } catch (e) { /* already gone */ } }
+                else if (typeof b.destroy === "function") { try { b.destroy(); } catch (e) { /* already gone */ } }
+            }
+            /*
+             * The engine marks and sizes the stage element it was given but does not unmark it,
+             * so a disposed book would otherwise leave a stage-shaped host behind. Handing the
+             * element back the way it was found is part of the contract's "no leaks".
+             */
+            if (host) {
+                Array.from(host.classList).forEach((name) => { if (name.indexOf("df-") === 0) host.classList.remove(name); });
+                ["position", "overflow", "background-color", "background-image", "height"].forEach((prop) => host.style.removeProperty(prop));
+            }
+            if (window.dFlipBook === b) window.dFlipBook = null;
+            if (window.flipbookInstance === b) window.flipbookInstance = null;
+            if (currentHandle === self) currentHandle = null;
+            engine = null;
+        };
+        Object.defineProperty(self, "disposed", { get: () => disposed });
+
+        /* The engine object itself. For this file and its own tests, and for nothing in `lib/`. */
+        Object.defineProperty(self, "engine", { get: book });
+    }
+
+    let currentHandle = null;
+
+    /** Whatever the engine currently regards as the open book, however it was opened. */
+    function liveEngine() {
+        return window.dFlipBook
+            || window.dfActiveLightBoxBook
+            || (window.DFLIP && window.DFLIP.activeBook)
+            || null;
+    }
+
+    /**
+     * The handle on the open document, or `null` when none is open. A book opened outside
+     * `create` -- the engine's own lightbox, say -- is adopted the first time it is asked for.
+     */
+    function current() {
+        if (currentHandle && !currentHandle.disposed && currentHandle.engine) return currentHandle;
+        const live = liveEngine();
+        if (!live) return null;
+        currentHandle = new Handle(live, null);
+        return currentHandle;
+    }
+
+    /** Translate the contract's option names into the ones the engine underneath expects. */
+    function engineOptions(options, handleRef) {
+        const given = options || {};
+        const out = {};
+        Object.keys(given).forEach((key) => { out[key] = given[key]; });
+
+        const direction = given.direction;
+        out.direction = (direction === "rtl" || direction === ENGINE_RTL) ? ENGINE_RTL : ENGINE_LTR;
+        out.hard = given.hard || "none";
+        out.openPage = given.openPage || 1;
+
+        /*
+         * Page turns are reported from here rather than from inside the engine, so a replacement
+         * engine needs to know nothing about page memory or about AppState.
+         */
+        out.onPageChanged = function (page) {
+            const pdfId = given.pdfId || given.source || null;
+            if (window.saveLastPage && pdfId) { try { window.saveLastPage(pdfId, page); } catch (e) { /* memory unavailable */ } }
+            if (window.appState && window.appState.setLastPage) window.appState.setLastPage(page);
+            if (typeof given.onPageChanged === "function") { try { given.onPageChanged(page); } catch (e) { /* a listener's problem */ } }
+        };
+
+        if (typeof given.onReady === "function") {
+            out.onReady = function () {
+                try { given.onReady(handleRef()); } catch (e) { console.error("ZayaBook onReady failed:", e); }
+            };
+        } else {
+            delete out.onReady;
+        }
+        return out;
+    }
+
+    /**
+     * Open `source` inside `container`.
+     * @param {Element|string} container the stage element, or a selector for it
+     * @param {string} source            the PDF to open
+     * @param {object} [options]         see `docs/engine-api.md`
+     * @returns {object} the handle, also published as `ZayaBook.current`
+     */
+    function create(container, source, options) {
+        const host = typeof container === "string" ? document.querySelector(container) : container;
+        if (!host) throw new Error("ZayaBook.create: no container");
+        if (!window.jQuery || !window.jQuery.fn || !window.jQuery.fn.flipBook) {
+            throw new Error("ZayaBook.create: the engine is not loaded");
+        }
+
+        let handle = null;
+        const resolved = engineOptions(options, () => handle);
+        const engine = window.jQuery(host).flipBook(source, resolved);
+        // The stage reads its own direction off the target; the instance carries it for everyone else.
+        engine.direction = resolved.direction;
+        handle = new Handle(engine, options || {});
+        currentHandle = handle;
+
+        // Deprecated aliases, kept for one release so plugins written against the old globals
+        // keep working. Nothing in `lib/` may read them.
+        window.flipbookInstance = engine;
+        window.dFlipBook = engine;
+        return handle;
+    }
+
+    window.ZayaBook = {
+        create,
+        /*
+         * How to find a stage in the document. A leaked stage has no API left to ask, so the
+         * contract test counts elements instead; publishing the selector here is what keeps that
+         * test engine-agnostic. A replacement engine names its own root class and nothing else
+         * changes.
+         */
+        stageSelector: "#flipbookContainer.df-container, #flipbookContainer .df-container",
+        get current() { return current(); },
+        /** True while a document is open and its pages can be turned. */
+        get isReady() { const b = current(); return !!(b && b.isReady()); },
+        dispose() { const b = current(); if (b) b.dispose(); }
+    };
+})();

--- a/lib/js/core/load.js
+++ b/lib/js/core/load.js
@@ -20,37 +20,38 @@ function engineText() {
 // Constants - now centralized in app-state.js for single source of truth
 const DEFAULT_PDF_URL = window.appState.constructor.getDefaultPdfUrl();
 
+/** The open document, through the one facade over the engine (see docs/engine-api.md). */
+function currentBook() {
+    return window.ZayaBook ? window.ZayaBook.current : null;
+}
+
+/*
+ * Both the reading direction and the stiff-page setting are load-time options of the engine, so
+ * changing either closes the document and opens it again on the same page.
+ */
+function reopenOnSamePage(rtlMode, reason) {
+    const book = currentBook();
+    if (!book || isCurrentlyLoading) return;
+
+    const currentPdf = window.appState.get('currentPdf');
+    const pdfId = window.ZayaCurrentDocKey();
+    const currentPage = book.activePage || 1;
+
+    book.dispose();
+    emptyFlipbookContainer();
+
+    loadFlipbook(currentPdf, rtlMode, currentPage, pdfId)
+        .catch((err) => console.error(`Failed to reopen after the ${reason} change:`, err));
+}
+
 // Subscribe to AppState changes for RTL and PDF updates
 window.appState.subscribe('isRTL', (newValue) => {
-    // Update flipbook direction if needed when RTL changes
-    if (typeof window.flipbookInstance !== 'undefined' && window.flipbookInstance && !isCurrentlyLoading) {
-        // Check current flipbook direction to avoid redundant reloads
-        const currentDirection = window.flipbookInstance.direction || 
-                                 (window.flipbookInstance.target ? window.flipbookInstance.target.direction : null);
-        const targetDirection = newValue ? 2 : 1;
-
-        if (currentDirection === targetDirection) return;
-
-        const currentPdf = window.appState.get('currentPdf');
-        const pdfId = window.ZayaCurrentDocKey();
-        
-        let currentPage = 1;
-        if (window.flipbookInstance.target && window.flipbookInstance.target._activePage) {
-            currentPage = window.flipbookInstance.target._activePage;
-        } else if (window.flipbookInstance._activePage) {
-            currentPage = window.flipbookInstance._activePage;
-        }
-
-        console.log('AppState RTL change detected, reloading flipbook for direction sync');
-        
-        // Clean up properly before direction toggle reload
-        if (window.flipbookInstance.dispose) {
-            try { window.flipbookInstance.dispose(); } catch(e) {}
-        }
-        emptyFlipbookContainer();
-
-        loadFlipbook(currentPdf, newValue, currentPage, pdfId);
-    }
+    const book = currentBook();
+    if (!book || isCurrentlyLoading) return;
+    // Already reading that way: nothing to reopen for.
+    if (book.direction === (newValue ? 'rtl' : 'ltr')) return;
+    console.log('AppState RTL change detected, reloading flipbook for direction sync');
+    reopenOnSamePage(newValue, 'reading-direction');
 });
 
 /*
@@ -58,25 +59,7 @@ window.appState.subscribe('isRTL', (newValue) => {
  * CSS renderers), so a change reopens the document on the same page, exactly as RTL does.
  */
 window.appState.subscribe('hardCover', () => {
-    if (typeof window.flipbookInstance === 'undefined' || !window.flipbookInstance || isCurrentlyLoading) return;
-
-    const currentPdf = window.appState.get('currentPdf');
-    const pdfId = window.ZayaCurrentDocKey();
-
-    let currentPage = 1;
-    if (window.flipbookInstance.target && window.flipbookInstance.target._activePage) {
-        currentPage = window.flipbookInstance.target._activePage;
-    } else if (window.flipbookInstance._activePage) {
-        currentPage = window.flipbookInstance._activePage;
-    }
-
-    if (window.flipbookInstance.dispose) {
-        try { window.flipbookInstance.dispose(); } catch (e) { /* already gone */ }
-    }
-    emptyFlipbookContainer();
-
-    loadFlipbook(currentPdf, window.appState.get('isRTL'), currentPage, pdfId)
-        .catch((err) => console.error('Failed to reopen after the stiff-page change:', err));
+    reopenOnSamePage(window.appState.get('isRTL'), 'stiff-page');
 });
 
 /** The stage the engine paints into; emptied before every load. */
@@ -173,7 +156,7 @@ async function loadFlipbook(pdfUrl, rtlMode, page, pdfId) {
         paddingBottom: 40,
         duration: 700,
         backgroundColor: "#2F2D2F",
-        direction: rtlMode ? 2 : 1, // Use 2 for RTL and 1 for LTR
+        direction: rtlMode ? 'rtl' : 'ltr',
         hard: window.appState.get('hardCover') || 'none', // 'none' | 'cover' | 'all'
         zoomChange: function (isZoomed) {
             document.body.style.overflow = isZoomed ? "hidden" : "auto";
@@ -192,12 +175,10 @@ async function loadFlipbook(pdfUrl, rtlMode, page, pdfId) {
                     name: isLocal ? (pdfId || 'Local PDF') : pdfUrl
                 });
             }
-            if (book && typeof book.pageCount !== 'undefined') {
-                console.log('PDF loaded successfully with', book.pageCount, 'pages');
-            }
+            if (book) console.log('PDF loaded successfully with', book.pageCount, 'pages');
             // Remembered More-menu choices first, so an explicit ?mode= still wins over them.
-            if (window.ZayaBookPrefs) window.ZayaBookPrefs.applyTo(window.flipbookInstance || book);
-            if (window.ZayaUrlOptions) window.ZayaUrlOptions.applyToBook(window.flipbookInstance || book);
+            if (window.ZayaBookPrefs) window.ZayaBookPrefs.applyTo(book);
+            if (window.ZayaUrlOptions) window.ZayaUrlOptions.applyToBook(book);
         },
     };
 
@@ -206,27 +187,27 @@ async function loadFlipbook(pdfUrl, rtlMode, page, pdfId) {
 
     // Clean up the previous document exactly once. Reloading the same document (RTL toggle)
     // must keep its blob: URL alive; switching documents revokes it.
-    if (window.flipbookInstance) {
-        const sameSource = !!(window.flipbookInstance.options && window.flipbookInstance.options.source === pdfUrl);
+    const previous = currentBook();
+    if (previous) {
+        const sameSource = previous.source === pdfUrl;
         window.memoryManager.cleanupPDF({ revokeBlobs: !sameSource });
-        window.flipbookInstance = null;
     }
 
     // Add error handling for PDF loading
-    let flipbookInstance = null;
+    let book = null;
     try {
-        flipbookInstance = $("#flipbookContainer").flipBook(pdfUrl, options);
-        window.flipbookInstance = flipbookInstance;
+        // load.js is the only caller of ZayaBook.create; every other module works from
+        // ZayaBook.current (see docs/engine-api.md).
+        book = window.ZayaBook.create('#flipbookContainer', pdfUrl, options);
 
-        if (flipbookInstance) {
+        if (book) {
             window.memoryManager.registerResource({
                 url: pdfUrl,
                 dispose: () => {
                     try {
-                        // The engine's own teardown removes its side panels wherever the Navigator
-                        // moved them, releases the pdf.js document and stops the render loop.
-                        if (typeof flipbookInstance.dispose === 'function') flipbookInstance.dispose();
-                        else if (typeof flipbookInstance.destroy === 'function') flipbookInstance.destroy();
+                        // The facade's teardown removes the engine's side panels wherever the
+                        // Navigator moved them, releases the pdf.js document and stops rendering.
+                        book.dispose();
                         emptyFlipbookContainer();
                     } catch (e) {
                         console.error('Error disposing flipbook:', e);
@@ -276,19 +257,10 @@ async function loadFlipbook(pdfUrl, rtlMode, page, pdfId) {
 
     // Update global PDF context
     updatePdfContext(pdfUrl, pdfId);
-    
-    if (flipbookInstance) {
-        window.flipbookInstance = flipbookInstance;
-    }
-    
-    if (window.flipbookInstance) {
-        window.flipbookInstance.direction = rtlMode ? 2 : 1;
-        if (window.flipbookInstance.ui && window.flipbookInstance.ui.update) {
-            window.flipbookInstance.ui.update();
-        }
-        if (window.flipbookInstance.resize) {
-            window.flipbookInstance.resize();
-        }
+
+    if (book) {
+        book.updateUi();
+        book.resize();
     }
     isCurrentlyLoading = false;
 }

--- a/lib/js/features/controls/custom-controls.js
+++ b/lib/js/features/controls/custom-controls.js
@@ -1,7 +1,7 @@
 /*
  * The bottom control bar, its More menu, and the two side drawers.
- * Plain DOM throughout: the flipbook engine still hands out jQuery objects (`fb.ui.*`,
- * `fb.target.searchContainer`), so those are unwrapped with `[0]` at the boundary.
+ * Plain DOM throughout. The book is reached only through `window.ZayaBook` (see
+ * `docs/engine-api.md`); nothing here knows what draws the pages.
  */
 function zayaWhenReady(fn) {
     if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", fn);
@@ -72,22 +72,16 @@ zayaWhenReady(function () {
 
         controlBar.classList.toggle("visible", mouseY > windowHeight - threshold || isHoveringBar || isMoreMenuOpen);
 
-        // Zoom fix: the engine's orbit control must let go while the pointer is over a side panel
+        // Zoom fix: the stage must let go while the pointer is over a side panel.
+        // LOCK rotation/pan over the panel, but leave the global scroll wheel free to zoom.
         const isHoveringSidebar = !!closestFrom(e.target, '.df-sidemenu');
         const fb = getFlipbook();
-        if (fb && fb.stage && fb.stage.orbitControl) {
-            // LOCK rotation/pan over the panel, but leave the global scroll wheel free to zoom
-            fb.stage.orbitControl.enabled = !isHoveringSidebar;
-        }
+        if (fb) fb.setInteractive(!isHoveringSidebar);
     });
 
-    // Flipbook Integration Helper
+    // The open document, through the one facade over the engine (see docs/engine-api.md).
     function getFlipbook() {
-        // More exhaustive check for the flipbook instance
-        if (window.dFlipBook) return window.dFlipBook;
-        const container = document.querySelector(".df-container");
-        const fromData = container && window.jQuery ? window.jQuery(container).data("dFlip") : null;
-        return fromData || window.dfActiveLightBoxBook || (window.DFLIP && window.DFLIP.activeBook) || null;
+        return window.ZayaBook ? window.ZayaBook.current : null;
     }
 
     // MutationObserver to prevent the library from removing our UI
@@ -127,34 +121,25 @@ zayaWhenReady(function () {
 
     // --- ONE DELEGATED CLICK HANDLER FOR THE WHOLE BAR ---
     const BAR_ACTIONS = {
-        customPrevBtn: (fb) => { if (fb.target && fb.target.prev) fb.target.prev(); else if (fb.prev) fb.prev(); },
-        customNextBtn: (fb) => { if (fb.target && fb.target.next) fb.target.next(); else if (fb.next) fb.next(); },
+        customPrevBtn: (fb) => fb.prev(),
+        customNextBtn: (fb) => fb.next(),
         customZoomInBtn: (fb) => fb.zoom(1),
         customZoomOutBtn: (fb) => fb.zoom(-1),
-        customFullscreenBtn: (fb) => { if (fb.ui) fb.ui.switchFullscreen(); },
-        menuFullscreenBtn: (fb) => { if (fb.ui) fb.ui.switchFullscreen(); },
-        customShareBtn: (fb) => { if (fb.ui && fb.ui.share && fb.ui.share[0]) fb.ui.share[0].click(); },
-        menuDownloadBtn: (fb) => {
-            if (fb.ui && fb.ui.download && fb.ui.download[0]) {
-                fb.ui.download[0].click();
-            } else if (fb.options && fb.options.source) {
-                const src = String(fb.options.source);
-                if (/^(https?:|blob:)/i.test(src)) window.open(src, '_blank', 'noopener');
-            }
-        },
+        customFullscreenBtn: (fb) => fb.toggleFullscreen(),
+        menuFullscreenBtn: (fb) => fb.toggleFullscreen(),
+        customShareBtn: (fb) => fb.share(),
+        menuDownloadBtn: (fb) => fb.download(),
         menuPageModeBtn: (fb) => {
-            const isSingle = fb.target.pageMode === 1;
-            fb.setPageMode(!isSingle, true);
-            rememberPageMode(!isSingle ? 'single' : 'double');
+            const wantSingle = fb.pageMode !== "single";
+            fb.setPageMode(wantSingle, true);
+            rememberPageMode(wantSingle ? 'single' : 'double');
             syncUI();
         },
-        menuFirstPageBtn: (fb) => fb.start(),
-        menuLastPageBtn: (fb) => fb.end(),
+        menuFirstPageBtn: (fb) => fb.first(),
+        menuLastPageBtn: (fb) => fb.last(),
         menuSoundBtn: (fb) => {
-            if (!fb.options) return;
-            const on = !isSoundOn(fb);
-            fb.options.soundEnable = on;
-            if (fb.ui && fb.ui.updateSound) fb.ui.updateSound();
+            const on = !fb.soundEnabled;
+            fb.setSoundEnabled(on);
             rememberSound(on);
             syncUI();
         }
@@ -196,8 +181,7 @@ zayaWhenReady(function () {
         if (!fb) return;
         const page = parseInt(input.value, 10);
         if (isNaN(page)) return;
-        if (fb.target && fb.target.gotoPage) fb.target.gotoPage(page);
-        else if (fb.gotoPage) fb.gotoPage(page);
+        fb.gotoPage(page);
     }
 
     const pageInput = el("customCurrentPageInput");
@@ -248,10 +232,6 @@ zayaWhenReady(function () {
     }
     function rememberPageMode(mode) { writePref(PAGE_MODE_KEY, mode); }
     function rememberSound(on) { writePref(SOUND_KEY, on ? "true" : "false"); }
-    function isSoundOn(fb) {
-        const value = fb.options ? fb.options.soundEnable : true;
-        return !(value === false || value === "false");
-    }
 
     window.ZayaBookPrefs = {
         pageMode: () => (readPref(PAGE_MODE_KEY) === "single" ? "single" : (readPref(PAGE_MODE_KEY) === "double" ? "double" : null)),
@@ -260,15 +240,11 @@ zayaWhenReady(function () {
         applyTo(book) {
             if (!book) return;
             const sound = this.soundEnabled();
-            if (sound !== null && book.options) {
-                book.options.soundEnable = sound;
-                if (book.ui && book.ui.updateSound) book.ui.updateSound();
-            }
+            if (sound !== null) book.setSoundEnabled(sound);
             const mode = this.pageMode();
-            if (mode && typeof book.setPageMode === "function") {
+            if (mode) {
                 const wantSingle = mode === "single";
-                const isSingle = book.target && book.target.pageMode === 1;
-                if (wantSingle !== isSingle) book.setPageMode(wantSingle, true);
+                if (wantSingle !== (book.pageMode === "single")) book.setPageMode(wantSingle, true);
             }
             syncUI();
         }
@@ -294,27 +270,20 @@ zayaWhenReady(function () {
         const fb = getFlipbook();
         if (!fb) return;
 
-        // Get current page from target or instance
-        const current = (fb.target && fb.target._activePage) || fb._activePage || 1;
-
-        // Get total pages from multiple possible locations
-        let total = 1;
-        if (fb.target && fb.target.pageCount) total = fb.target.pageCount;
-        else if (fb.pageCount) total = fb.pageCount;
-        else if (fb.contentProvider && fb.contentProvider.pageCount) total = fb.contentProvider.pageCount;
+        const current = fb.activePage;
+        const total = fb.pageCount || 1;
 
         const input = el("customCurrentPageInput");
         if (input && document.activeElement !== input) input.value = current;
         setText("customTotalPages", total);
 
         // Sync Page Mode
-        const pageMode = (fb.target && fb.target.pageMode) || fb.pageMode;
-        const isSingle = pageMode === 1;
+        const isSingle = fb.pageMode === "single";
         setLabel("menuPageModeBtn", t(isSingle ? "more.doublePage" : "more.singlePage"));
         setIcon("menuPageModeBtn", isSingle ? "fas fa-book-open" : "fas fa-file-alt");
 
         // Sync Sound
-        const soundOn = isSoundOn(fb);
+        const soundOn = fb.soundEnabled;
         setLabel("menuSoundBtn", t(soundOn ? "more.soundOn" : "more.soundOff"));
         setIcon("menuSoundBtn", soundOn ? "fas fa-volume-up" : "fas fa-volume-mute");
 
@@ -358,7 +327,6 @@ window.ZayaNavigator = (function () {
     const PANE_ID = { thumbs: "navPaneThumbs", outline: "navPaneOutline", search: "navPaneSearch", text: "navPaneText" };
     const TAB_ID = { thumbs: "navTabThumbs", outline: "navTabOutline", search: "navTabSearch", text: "navTabText" };
     const BAR_ID = { thumbs: "customThumbnailBtn", outline: "customOutlineBtn", search: "customSearchBtn" };
-    const UI_KEY = { thumbs: "thumbnail", outline: "outline", search: "searchPanel" };
     const t = (key, vars) => (window.ZayaI18n ? window.ZayaI18n.t(key, vars) : key);
     const EMPTY = {
         thumbs: { icon: "fas fa-images", key: "nav.empty.thumbs" },
@@ -404,7 +372,7 @@ window.ZayaNavigator = (function () {
     const drawer = () => el("navigatorDrawer");
     const bodyEl = () => el("navigatorBody");
     const pane = (tab) => document.querySelector(SELECTOR[tab]);
-    const book = () => window.dFlipBook || (window.DFLIP && window.DFLIP.activeBook) || null;
+    const book = () => (window.ZayaBook ? window.ZayaBook.current : null);
     const isSheet = () => (window.ZayaDrawers ? window.ZayaDrawers.isSheet() : window.matchMedia("(max-width: 767.98px)").matches);
     const isDocked = () => (window.ZayaDrawers ? window.ZayaDrawers.isDocked() : window.matchMedia("(min-width: 1200px)").matches);
 
@@ -439,11 +407,8 @@ window.ZayaNavigator = (function () {
     function ensure(tab) {
         if (tab === "text") { if (textPane()) textPane().ensure(); return; }
         const fb = book();
-        const cp = fb && fb.contentProvider;
-        if (!cp) return;
-        if (tab === "thumbs" && !pane("thumbs") && cp.initThumbs) cp.initThumbs();
-        if (tab === "outline" && !pane("outline") && cp.initOutline) cp.initOutline();
-        if (tab === "search" && !pane("search") && cp.initSearch) cp.initSearch();
+        if (!fb) return;
+        fb.ensurePanel(tab);
         adopt();
     }
 
@@ -476,11 +441,9 @@ window.ZayaNavigator = (function () {
             const on = isOpen && tab === activeTab;
             const btn = el(BAR_ID[tab]);
             if (btn) btn.classList.toggle("active", on);
-            // `fb.ui.*` are jQuery-wrapped engine elements; unwrap before touching classes
-            const uiEl = fb && fb.ui && fb.ui[UI_KEY[tab]] ? fb.ui[UI_KEY[tab]][0] : null;
-            if (uiEl) uiEl.classList.toggle("df-active", on);
+            if (fb) fb.setPanelActive(tab, on);
         });
-        if (fb && fb.ui && fb.ui.update) fb.ui.update(true);
+        if (fb) fb.updateUi(true);
     }
 
     function paint() {
@@ -693,8 +656,8 @@ window.ZayaDrawers = window.ZayaDrawers || {
 
     /* Re-lay the book after the drawers changed the width of the reading area. */
     resizeBook() {
-        const fb = window.dFlipBook || (window.DFLIP && window.DFLIP.activeBook) || null;
-        if (fb && typeof fb.resize === "function") fb.resize();
+        const fb = window.ZayaBook ? window.ZayaBook.current : null;
+        if (fb) fb.resize();
         else window.dispatchEvent(new Event("resize"));
     },
 

--- a/lib/js/features/print/print.js
+++ b/lib/js/features/print/print.js
@@ -38,31 +38,30 @@
     let isOpen = false;
     let objectUrls = [];
 
+    /** The open document, through the one facade over the engine (see docs/engine-api.md). */
     function book() {
-        return window.dFlipBook || window.flipbookInstance || (window.DFLIP && window.DFLIP.activeBook) || null;
+        return window.ZayaBook ? window.ZayaBook.current : null;
     }
 
     function pdfDocument() {
         const fb = book();
-        return (fb && fb.contentProvider && fb.contentProvider.pdfDocument) || null;
+        return (fb && fb.pdfDocument) || null;
     }
 
     function pageCount() {
         const doc = pdfDocument();
         if (doc && doc.numPages) return doc.numPages;
         const fb = book();
-        if (fb && fb.target && fb.target.pageCount) return fb.target.pageCount;
-        return 0;
+        return (fb && fb.pageCount) || 0;
     }
 
     /** The page (or spread) the reader is looking at, as PDF page numbers. */
     function currentPages() {
         const fb = book();
         const total = pageCount();
-        if (!total) return [];
-        const active = (fb && fb.target && fb.target._activePage) || (fb && fb._activePage) || 1;
-        const pageMode = (fb && fb.target && fb.target.pageMode) || (fb && fb.pageMode) || 0;
-        if (pageMode !== 2) return [clamp(active, total)];
+        if (!fb || !total) return [];
+        const active = fb.activePage;
+        if (fb.pageMode !== "double") return [clamp(active, total)];
         // A double-page spread shows an even page beside the odd one that follows it.
         const left = active % 2 === 0 ? active : active - 1;
         return dedupe([left, left + 1].filter((n) => n >= 1 && n <= total));
@@ -264,10 +263,8 @@
         await page.render({ canvasContext: ctx, viewport }).promise;
 
         if (includeMarks) {
-            const cp = book() && book().contentProvider;
-            if (cp && typeof cp.drawSearchHighlights === "function") {
-                try { cp.drawSearchHighlights(ctx, viewport, pageNumber); } catch (e) { /* nothing to paint */ }
-            }
+            const fb = book();
+            if (fb) fb.drawSearchHighlights(ctx, viewport, pageNumber);
         }
 
         const img = document.createElement("img");

--- a/lib/js/features/text/text-pane.js
+++ b/lib/js/features/text/text-pane.js
@@ -16,9 +16,6 @@ window.ZayaTextPane = (function () {
     "use strict";
 
     const PANE_ID = "navPaneText";
-    // PAGE_SIZE.DOUBLEINTERNAL: one PDF page holds a whole spread and becomes two book pages.
-    const DOUBLE_INTERNAL = 2;
-    const PAGE_MODE_SINGLE = 1;
 
     let pane = null;          // the pane element, once built
     let list = null;          // the scrolling column of page sections
@@ -42,51 +39,25 @@ window.ZayaTextPane = (function () {
         }).showToast();
     }
 
-    const book = () => window.dFlipBook || (window.DFLIP && window.DFLIP.activeBook) || null;
-    const provider = () => { const fb = book(); return (fb && fb.contentProvider) || null; };
+    const book = () => (window.ZayaBook ? window.ZayaBook.current : null);
 
     /**
      * The search index, created on demand: the Text pane may be the first thing the reader opens,
-     * and the engine only builds the search panel when its own tab is asked for.
+     * and the search panel is only built when its own tab is asked for.
      */
     function controller() {
-        const cp = provider();
-        if (!cp) return null;
-        if (!cp.searchController && typeof cp.initSearch === "function") {
-            cp.initSearch();
-            if (window.ZayaNavigator) window.ZayaNavigator.adopt();
-        }
-        return cp.searchController || null;
-    }
-
-    /** Book page → PDF page: the inverse of the search panel's `toBookPage`. */
-    function toPdfPage(bookPage) {
-        const cp = provider();
-        const pageSize = cp && cp.options ? cp.options.pageSize : 0;
-        if (pageSize === DOUBLE_INTERNAL && bookPage > 2) return Math.ceil((bookPage - 1) / 2) + 1;
-        return bookPage;
+        const fb = book();
+        if (!fb) return null;
+        const had = !!fb.searchController;
+        const ctrl = fb.ensureSearch();
+        if (ctrl && !had && window.ZayaNavigator) window.ZayaNavigator.adopt();
+        return ctrl;
     }
 
     /** The PDF pages of the spread on screen: one page in single mode, the pair in double mode. */
     function visiblePdfPages() {
         const fb = book();
-        const target = fb && fb.target;
-        if (!target) return [];
-        const count = target.pageCount || fb.pageCount || 1;
-        const active = Math.max(1, Math.min(count, target._activePage || 1));
-        let pages = [active];
-        if (target.pageMode !== PAGE_MODE_SINGLE) {
-            // The engine shows the spread that starts at the even page below the active one.
-            const base = Math.floor(active / 2) * 2;
-            pages = [base, base + 1];
-        }
-        const out = [];
-        pages.forEach((p) => {
-            if (p < 1 || p > count) return;
-            const pdf = toPdfPage(p);
-            if (out.indexOf(pdf) === -1) out.push(pdf);
-        });
-        return out;
+        return fb ? fb.visiblePdfPages() : [];
     }
 
     /**
@@ -290,11 +261,11 @@ window.ZayaTextPane = (function () {
                 if (!window.ZayaNavigator) return;
                 window.ZayaNavigator.setTab("search");
                 setTimeout(() => {
-                    const input = document.querySelector(".df-search-input");
-                    if (!input) return;
-                    input.value = query;
-                    input.dispatchEvent(new Event("input", { bubbles: true }));
-                    input.focus();
+                    const fb = book();
+                    if (!fb) return;
+                    fb.openSearch(query);
+                    const input = fb.searchInput();
+                    if (input) input.focus();
                 }, 80);
             })
         );

--- a/lib/js/utils/url-options.js
+++ b/lib/js/utils/url-options.js
@@ -58,29 +58,16 @@
         }
     }
 
-    // Called from load.js once the flipbook reports ready
+    // Called from load.js once the book reports ready; `book` is a ZayaBook handle.
     function applyToBook(book) {
         if (!book) return;
-        if (options.mode && typeof book.setPageMode === 'function') {
+        if (options.mode) {
             const wantSingle = options.mode === 'single';
-            const isSingle = book.target && book.target.pageMode === 1;
-            if (wantSingle !== isSingle) book.setPageMode(wantSingle, true);
+            if (wantSingle !== (book.pageMode === 'single')) book.setPageMode(wantSingle, true);
         }
-        if (options.search && book.ui && book.ui.searchPanel) {
+        if (options.search) {
             const term = options.search;
-            // The engine hands out jQuery objects here, so unwrap before touching the DOM.
-            setTimeout(() => {
-                const container = book.target.searchContainer ? book.target.searchContainer[0] : null;
-                if (!(container && container.classList.contains('df-sidemenu-visible'))) {
-                    const opener = book.ui.searchPanel[0];
-                    if (opener) opener.click();
-                }
-                const input = book.target.searchInput ? book.target.searchInput[0] : null;
-                if (input) {
-                    input.value = term;
-                    input.dispatchEvent(new Event('input', { bubbles: true }));
-                }
-            }, 300);
+            setTimeout(() => book.openSearch(term), 300);
         }
         options.search = null; // apply once
     }

--- a/tests/engine-contract.spec.mjs
+++ b/tests/engine-contract.spec.mjs
@@ -1,0 +1,446 @@
+/**
+ * The engine contract (issue #21, step E1).
+ *
+ * Every member `docs/engine-api.md` marks KEEP is exercised here through `window.ZayaBook` and
+ * nothing else. The assertions are about behaviour -- pages turn, mappings hold, teardown leaves
+ * no stage behind -- never about the shapes of whatever draws the pages, so a clean-room engine
+ * can be pointed at this same file and told to make it pass.
+ *
+ * The one exception is the leak check, which counts stage elements by class name because a leaked
+ * stage has no API to ask. It reads them from `ZayaBook.stageSelector` (published by the facade
+ * for exactly this reason), so a replacement engine names its own.
+ */
+import { test, expect } from '@playwright/test';
+import { stubNetwork, collectErrors } from './helpers.mjs';
+
+const FIXTURES = new URL('./fixtures/', import.meta.url).pathname;
+
+/** Wait until a document is open and its pages can be turned, asking only the facade. */
+async function ready(page) {
+  await expect
+    .poll(() => page.evaluate(() => !!(window.ZayaBook && window.ZayaBook.isReady)), { timeout: 30_000 })
+    .toBe(true);
+  await expect
+    .poll(() => page.evaluate(() => window.ZayaBook.current.pageCount), { timeout: 30_000 })
+    .toBeGreaterThan(0);
+}
+
+/** Read a set of properties off the open book in one round trip. */
+function stateOf(page) {
+  return page.evaluate(() => {
+    const b = window.ZayaBook.current;
+    return {
+      activePage: b.activePage,
+      pageCount: b.pageCount,
+      pageMode: b.pageMode,
+      direction: b.direction,
+      renderMode: b.renderMode,
+      hardCover: b.hardCover,
+      source: b.source,
+      soundEnabled: b.soundEnabled,
+      isReady: b.isReady(),
+      disposed: b.disposed,
+      visiblePdfPages: b.visiblePdfPages()
+    };
+  });
+}
+
+const activePage = (page) => page.evaluate(() => window.ZayaBook.current.activePage);
+
+/** Open a fixture through the app's own file picker and wait for it. */
+async function openFixture(page, name) {
+  const panel = page.locator('#unifiedPanel');
+  if (!(await panel.evaluate((el) => el.classList.contains('open')))) {
+    await page.locator('#toggleUnifiedPanelBtn').click();
+  }
+  const tab = page.locator('#panelTabDocument');
+  if (await tab.count()) await tab.click();
+  await page.setInputFiles('#pdfFile', FIXTURES + name);
+  await expect
+    .poll(() => page.evaluate(() => window.appState.get('currentPdfName')), { timeout: 25_000 })
+    .toBe(name);
+  await ready(page);
+}
+
+test.describe('ZayaBook contract', () => {
+  test('the facade is the app-facing surface and reports the open document', async ({ page }) => {
+    await stubNetwork(page);
+    await page.goto('/index.html?pdf=https://example.com/sample.pdf');
+    await ready(page);
+
+    const shape = await page.evaluate(() => {
+      const api = window.ZayaBook;
+      const b = api.current;
+      const kind = (name) => typeof b[name];
+      return {
+        namespace: ['create', 'current', 'isReady', 'dispose'].every((k) => k in api),
+        createIsFunction: typeof api.create === 'function',
+        methods: ['gotoPage', 'next', 'prev', 'first', 'last', 'setPageMode', 'toBookPage', 'toPdfPage',
+          'visiblePdfPages', 'ensureSearch', 'setSearchHighlight', 'drawSearchHighlights',
+          'refreshVisiblePages', 'ensurePanel', 'panel', 'setPanelActive', 'searchInput', 'openSearch',
+          'updateUi', 'toggleFullscreen', 'share', 'download', 'zoom', 'resize', 'setInteractive',
+          'setSoundEnabled', 'dispose', 'isReady'].map(kind),
+        properties: ['source', 'renderMode', 'hardCover', 'activePage', 'pageCount', 'pageMode',
+          'direction', 'pdfDocument', 'spreadPerPdfPage', 'searchController', 'soundEnabled',
+          'interactive', 'disposed'].filter((k) => !(k in b))
+      };
+    });
+    expect(shape.namespace).toBe(true);
+    expect(shape.createIsFunction).toBe(true);
+    expect(shape.methods.every((t) => t === 'function')).toBe(true);
+    expect(shape.properties).toEqual([]);
+
+    const state = await stateOf(page);
+    expect(state.pageCount).toBe(3);
+    expect(state.activePage).toBe(1);
+    expect(state.pageMode).toBe('double');
+    expect(state.direction).toBe('ltr');
+    expect(state.hardCover).toBe('none');
+    expect(state.isReady).toBe(true);
+    expect(state.disposed).toBe(false);
+    expect(String(state.source)).toContain('sample.pdf');
+    expect(['webgl', 'css']).toContain(state.renderMode);
+
+    // The pdf.js proxy is the document itself, and agrees with the book about its length.
+    expect(await page.evaluate(() => window.ZayaBook.current.pdfDocument.numPages)).toBe(3);
+  });
+
+  test('navigation turns pages and the page-change event follows', async ({ page }) => {
+    await stubNetwork(page);
+    await page.goto('/index.html?pdf=https://example.com/sample.pdf');
+    await ready(page);
+
+    // Every page turn is announced on `document` as zaya:pageChanged.
+    await page.evaluate(() => {
+      window.__pages = [];
+      document.addEventListener('zaya:pageChanged', (e) => window.__pages.push(e.detail.page));
+    });
+
+    expect(await page.evaluate(() => window.ZayaBook.current.gotoPage(3))).toBeGreaterThan(0);
+    await expect.poll(() => activePage(page), { timeout: 15_000 }).toBe(3);
+
+    await page.evaluate(() => window.ZayaBook.current.prev());
+    await expect.poll(() => activePage(page), { timeout: 15_000 }).toBe(1);
+
+    await page.evaluate(() => window.ZayaBook.current.next());
+    await expect.poll(() => activePage(page), { timeout: 15_000 }).toBe(3);
+
+    await page.evaluate(() => window.ZayaBook.current.first());
+    await expect.poll(() => activePage(page), { timeout: 15_000 }).toBe(1);
+
+    await page.evaluate(() => window.ZayaBook.current.last());
+    await expect.poll(() => activePage(page), { timeout: 15_000 }).toBeGreaterThan(1);
+
+    // A page beyond the end is clamped rather than accepted.
+    await page.evaluate(() => window.ZayaBook.current.gotoPage(9999));
+    await expect
+      .poll(() => page.evaluate(() => window.ZayaBook.current.activePage <= window.ZayaBook.current.pageCount))
+      .toBe(true);
+
+    await expect.poll(() => page.evaluate(() => window.__pages.length), { timeout: 15_000 }).toBeGreaterThan(1);
+  });
+
+  test('page mode switches and the pdf-to-book mapping holds in both modes', async ({ page }) => {
+    await stubNetwork(page);
+    await page.goto('/index.html?pdf=https://example.com/sample.pdf');
+    await ready(page);
+
+    // Double mode: the spread is the even page and the odd one after it.
+    await page.evaluate(() => window.ZayaBook.current.gotoPage(2));
+    await expect.poll(() => activePage(page), { timeout: 15_000 }).toBe(2);
+    let state = await stateOf(page);
+    expect(state.pageMode).toBe('double');
+    expect(state.visiblePdfPages).toEqual([2, 3]);
+
+    expect(await page.evaluate(() => window.ZayaBook.current.setPageMode(true, true))).toBe('single');
+    await expect.poll(() => page.evaluate(() => window.ZayaBook.current.pageMode), { timeout: 15_000 }).toBe('single');
+    state = await stateOf(page);
+    expect(state.visiblePdfPages).toEqual([state.activePage]);
+
+    expect(await page.evaluate(() => window.ZayaBook.current.setPageMode(false, true))).toBe('double');
+    await expect.poll(() => page.evaluate(() => window.ZayaBook.current.pageMode), { timeout: 15_000 }).toBe('double');
+
+    // A document laid out one page per sheet maps book pages and PDF pages one to one, both ways.
+    const mapping = await page.evaluate(() => {
+      const b = window.ZayaBook.current;
+      const rows = [];
+      for (let n = 1; n <= b.pageCount; n++) rows.push([n, b.toPdfPage(n), b.toBookPage(b.toPdfPage(n))]);
+      return { spread: b.spreadPerPdfPage, rows };
+    });
+    expect(mapping.spread).toBe(false);
+    for (const [book, pdf, back] of mapping.rows) {
+      expect(pdf).toBe(book);
+      expect(back).toBe(book);
+    }
+
+    // The mapping is a total function: it never leaves the document, whatever it is handed.
+    const edges = await page.evaluate(() => {
+      const b = window.ZayaBook.current;
+      return [0, -3, 1.5, NaN, b.pageCount + 50].map((n) => [b.toPdfPage(n), b.toBookPage(n)]);
+    });
+    for (const [pdf, book] of edges) {
+      expect(pdf).toBeGreaterThanOrEqual(1);
+      expect(book).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  test('right-to-left is reported and survives a reopen on the same page', async ({ page }) => {
+    await stubNetwork(page);
+    await page.goto('/index.html?pdf=https://example.com/sample.pdf&rtl=1');
+    await ready(page);
+    await expect.poll(() => page.evaluate(() => window.ZayaBook.current.direction), { timeout: 25_000 }).toBe('rtl');
+
+    // An Arabic document reads the same way; the direction is the app's, not the document's.
+    await openFixture(page, 'sample-arabic.pdf');
+    expect((await stateOf(page)).direction).toBe('rtl');
+
+    // Toggling back reopens the book, on the page it was left at.
+    await page.evaluate(() => window.ZayaBook.current.gotoPage(2));
+    await expect.poll(() => activePage(page), { timeout: 15_000 }).toBe(2);
+    await page.evaluate(() => window.appState.set({ isRTL: false }));
+    await expect.poll(() => page.evaluate(() => window.ZayaBook.current && window.ZayaBook.current.direction), { timeout: 30_000 }).toBe('ltr');
+    await ready(page);
+    expect(await activePage(page)).toBeGreaterThan(1);
+  });
+
+  test('the outline and thumbnail panels are built on demand and rebuilt per document', async ({ page }) => {
+    await stubNetwork(page);
+    await page.goto('/index.html');
+    await ready(page);
+    await openFixture(page, 'sample-outline.pdf');
+
+    const panels = await page.evaluate(() => {
+      const b = window.ZayaBook.current;
+      const before = { thumbs: !!b.panel('thumbs'), outline: !!b.panel('outline') };
+      const built = { thumbs: !!b.ensurePanel('thumbs'), outline: !!b.ensurePanel('outline'), search: !!b.ensurePanel('search') };
+      // Asking twice must not build a second one.
+      b.ensurePanel('thumbs');
+      b.ensurePanel('outline');
+      return { before, built, unknown: b.ensurePanel('nonsense') };
+    });
+    expect(panels.built.thumbs).toBe(true);
+    expect(panels.built.outline).toBe(true);
+    expect(panels.built.search).toBe(true);
+    expect(panels.unknown).toBe(null);
+
+    // One panel of each kind, wherever the app has re-parented it.
+    const counts = await page.evaluate(() => {
+      const b = window.ZayaBook.current;
+      return ['thumbs', 'outline', 'search'].map((name) => document.querySelectorAll(
+        b.panel(name) ? b.panel(name).className.split(/\s+/).filter(Boolean).map((c) => '.' + c).join('') : ':not(*)'
+      ).length);
+    });
+    for (const n of counts) expect(n).toBe(1);
+
+    // A document with no outline replaces the panels rather than keeping the old ones.
+    await openFixture(page, 'sample.pdf');
+    await page.evaluate(() => window.ZayaBook.current.ensurePanel('outline'));
+    expect(await page.locator('.df-outline-container').count()).toBe(1);
+  });
+
+  test('search: the controller indexes, highlights repaint and marks are drawable', async ({ page }) => {
+    await stubNetwork(page);
+    await page.goto('/index.html?pdf=https://example.com/sample.pdf');
+    await ready(page);
+
+    // ensureSearch is idempotent and hands back the same controller.
+    const same = await page.evaluate(() => {
+      const b = window.ZayaBook.current;
+      const first = b.ensureSearch();
+      return !!first && first === b.ensureSearch() && first === b.searchController;
+    });
+    expect(same).toBe(true);
+
+    await page.evaluate(() => window.ZayaBook.current.searchController.index());
+    await expect
+      .poll(() => page.evaluate(() => window.ZayaBook.current.searchController.getHighlightRects(3, 'zebra').length), { timeout: 25_000 })
+      .toBeGreaterThan(0);
+
+    // Setting a query repaints the visible pages, and clearing it repaints them again.
+    await page.evaluate(() => {
+      const b = window.ZayaBook.current;
+      b.setSearchHighlight('zebra');
+      b.refreshVisiblePages();
+    });
+    await page.evaluate(() => window.ZayaBook.current.gotoPage(3));
+    await expect.poll(() => activePage(page), { timeout: 15_000 }).toBe(3);
+
+    // The marks a printed sheet carries are drawn through the same call, onto any 2D context.
+    const painted = await page.evaluate(async () => {
+      const b = window.ZayaBook.current;
+      const pdfPage = await b.pdfDocument.getPage(3);
+      const viewport = pdfPage.getViewport({ scale: 1 });
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.ceil(viewport.width);
+      canvas.height = Math.ceil(viewport.height);
+      const ctx = canvas.getContext('2d');
+      const withQuery = b.drawSearchHighlights(ctx, viewport, 3);
+      b.setSearchHighlight('');
+      const withoutQuery = b.drawSearchHighlights(ctx, viewport, 3);
+      return { withQuery, withoutQuery };
+    });
+    expect(painted.withQuery).toBe(true);
+    expect(painted.withoutQuery).toBe(false);
+
+    // openSearch fills the panel's own field, whichever module built it.
+    await page.evaluate(() => window.ZayaBook.current.openSearch('zebra'));
+    await expect
+      .poll(() => page.evaluate(() => { const i = window.ZayaBook.current.searchInput(); return i ? i.value : null; }), { timeout: 15_000 })
+      .toBe('zebra');
+  });
+
+  test('sound, zoom, resize and the chrome hooks are all callable', async ({ page }) => {
+    await stubNetwork(page);
+    const errors = collectErrors(page);
+    await page.goto('/index.html?pdf=https://example.com/sample.pdf');
+    await ready(page);
+
+    const sound = await page.evaluate(() => {
+      const b = window.ZayaBook.current;
+      b.setSoundEnabled(false);
+      const off = b.soundEnabled;
+      b.setSoundEnabled(true);
+      return { off, on: b.soundEnabled };
+    });
+    expect(sound.off).toBe(false);
+    expect(sound.on).toBe(true);
+
+    const interactive = await page.evaluate(() => {
+      const b = window.ZayaBook.current;
+      b.setInteractive(false);
+      const locked = b.interactive;
+      b.setInteractive(true);
+      return { locked, free: b.interactive };
+    });
+    // A renderer with no orbiting stage reports itself interactive throughout, which is fine.
+    expect(typeof interactive.locked).toBe('boolean');
+    expect(interactive.free).toBe(true);
+
+    // Zoom, resize and the panel-state hooks must be safe to call and must not throw.
+    await page.evaluate(() => {
+      const b = window.ZayaBook.current;
+      b.zoom(1);
+      b.zoom(-1);
+      b.resize();
+      b.updateUi(true);
+      b.setPanelActive('thumbs', true);
+      b.setPanelActive('thumbs', false);
+      b.setPanelActive('nonsense', true);
+    });
+    await ready(page);
+    expect(await activePage(page)).toBeGreaterThan(0);
+
+    const ignorable = /favicon|sw\.js|Service Worker|THREE|WebGL|GPU|api\.github\.com|pro-features|404|Failed to load resource/i;
+    expect(errors.filter((e) => !ignorable.test(e))).toEqual([]);
+  });
+
+  test('dispose tears the book down and leaves no stage behind', async ({ page }) => {
+    await stubNetwork(page);
+    await page.goto('/index.html?pdf=https://example.com/sample.pdf');
+    await ready(page);
+
+    const before = await page.evaluate(() => ({
+      stages: document.querySelectorAll(window.ZayaBook.stageSelector).length,
+      canvases: document.querySelectorAll('#flipbookContainer canvas').length
+    }));
+    expect(before.stages).toBe(1);
+
+    const after = await page.evaluate(() => {
+      const b = window.ZayaBook.current;
+      b.dispose();
+      const twice = (() => { b.dispose(); return true; })(); // disposing twice is a no-op
+      return {
+        twice,
+        disposed: b.disposed,
+        current: window.ZayaBook.current,
+        isReady: window.ZayaBook.isReady,
+        // A disposed handle answers quietly instead of throwing.
+        activePage: b.activePage,
+        pageCount: b.pageCount,
+        pdfDocument: b.pdfDocument,
+        source: b.source,
+        stillReady: b.isReady(),
+        stages: document.querySelectorAll(window.ZayaBook.stageSelector).length,
+        canvases: document.querySelectorAll('#flipbookContainer canvas').length
+      };
+    });
+    expect(after.twice).toBe(true);
+    expect(after.disposed).toBe(true);
+    expect(after.current).toBe(null);
+    expect(after.isReady).toBe(false);
+    expect(after.activePage).toBe(1);
+    expect(after.pageCount).toBe(0);
+    expect(after.pdfDocument).toBe(null);
+    expect(after.source).toBe(null);
+    expect(after.stillReady).toBe(false);
+    expect(after.stages).toBe(0);
+    expect(after.canvases).toBe(0);
+  });
+
+  test('reopening a document leaves exactly one stage behind it', async ({ page }) => {
+    await stubNetwork(page);
+    await page.goto('/index.html');
+    await ready(page);
+    const stages = () => page.evaluate(() => document.querySelectorAll(window.ZayaBook.stageSelector).length);
+    expect(await stages()).toBe(1);
+
+    await openFixture(page, 'sample-outline.pdf');
+    expect(await stages()).toBe(1);
+    await openFixture(page, 'sample-arabic.pdf');
+    expect(await stages()).toBe(1);
+    await openFixture(page, 'sample.pdf');
+    expect(await stages()).toBe(1);
+  });
+
+  test('the renderer can be pinned with ?render=css and the contract is unchanged', async ({ page }) => {
+    await stubNetwork(page);
+    await page.goto('/index.html?render=css&pdf=https://example.com/sample.pdf');
+    await ready(page);
+
+    expect(await page.evaluate(() => window.ZayaBook.current.renderMode)).toBe('css');
+    // No WebGL stage: the 2D renderer paints without one.
+    expect(await page.evaluate(() => document.querySelectorAll('#flipbookContainer > canvas').length)).toBe(0);
+
+    // Everything the contract promises still holds in the other renderer.
+    const state = await stateOf(page);
+    expect(state.pageCount).toBe(3);
+    expect(state.pageMode).toBe('double');
+
+    await page.evaluate(() => window.ZayaBook.current.next());
+    await expect.poll(() => activePage(page), { timeout: 20_000 }).toBe(3);
+    await page.evaluate(() => window.ZayaBook.current.setPageMode(true, true));
+    await expect.poll(() => page.evaluate(() => window.ZayaBook.current.pageMode), { timeout: 15_000 }).toBe('single');
+    await page.evaluate(() => window.ZayaBook.current.ensureSearch().index());
+    await expect
+      .poll(() => page.evaluate(() => window.ZayaBook.current.searchController.getHighlightRects(3, 'zebra').length), { timeout: 25_000 })
+      .toBeGreaterThan(0);
+  });
+
+  test('the stiff-page option is applied and reported at load time', async ({ page }) => {
+    await stubNetwork(page);
+    await page.goto('/index.html?pdf=https://example.com/sample.pdf');
+    await ready(page);
+    expect((await stateOf(page)).hardCover).toBe('none');
+
+    await page.evaluate(() => window.appState.setHardCover('cover'));
+    await expect.poll(() => page.evaluate(() => window.ZayaBook.current && window.ZayaBook.current.hardCover), { timeout: 30_000 }).toBe('cover');
+    await ready(page);
+    expect(await page.evaluate(() => document.querySelectorAll(window.ZayaBook.stageSelector).length)).toBe(1);
+
+    await page.evaluate(() => window.appState.setHardCover('all'));
+    await expect.poll(() => page.evaluate(() => window.ZayaBook.current && window.ZayaBook.current.hardCover), { timeout: 30_000 }).toBe('all');
+    await ready(page);
+    // The book still turns pages with stiff sheets.
+    await page.evaluate(() => window.ZayaBook.current.next());
+    await expect.poll(() => activePage(page), { timeout: 20_000 }).toBeGreaterThan(1);
+  });
+
+  test('the deprecated globals still point at the open book', async ({ page }) => {
+    await stubNetwork(page);
+    await page.goto('/index.html?pdf=https://example.com/sample.pdf');
+    await ready(page);
+    // Kept for one release so plugins written against them keep working; nothing in lib/ reads them.
+    expect(await page.evaluate(() => !!window.dFlipBook)).toBe(true);
+    expect(await page.evaluate(() => window.dFlipBook === window.flipbookInstance)).toBe(true);
+  });
+});

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -33,7 +33,7 @@ export function collectErrors(page) {
 export async function waitForBook(page) {
   await expect(page.locator('#flipbookContainer canvas, #flipbookContainer .df-book-page').first())
     .toBeVisible({ timeout: 30_000 });
-  await expect.poll(() => page.evaluate(() => !!(window.dFlipBook && window.dFlipBook.target)), { timeout: 15_000 })
+  await expect.poll(() => page.evaluate(() => !!(window.ZayaBook && window.ZayaBook.isReady)), { timeout: 15_000 })
     .toBe(true);
 }
 
@@ -49,12 +49,12 @@ export async function openPanel(page, tab = 'Document') {
 }
 
 export async function activePage(page) {
-  return page.evaluate(() => (window.dFlipBook && window.dFlipBook.target ? window.dFlipBook.target._activePage : null));
+  return page.evaluate(() => (window.ZayaBook && window.ZayaBook.current ? window.ZayaBook.current.activePage : null));
 }
 
 /** Turn to `n` and wait until page memory has stored it for `key`. */
 export async function goToPage(page, n, key) {
-  await page.evaluate((target) => window.dFlipBook.target.gotoPage(target), n);
+  await page.evaluate((target) => window.ZayaBook.current.gotoPage(target), n);
   await expect.poll(() => activePage(page), { timeout: 15_000 }).toBe(n);
   if (key) {
     await expect.poll(() => page.evaluate((k) => window.getLastPage(k), key), { timeout: 15_000 }).toBe(n);


### PR DESCRIPTION
## Summary

First step of the engine replacement (#21). Nothing changes for readers; the change is who is allowed to talk to the engine.

- **`docs/engine-api.md`** freezes the engine's public contract, written from the app's usage and observable behaviour rather than the fork's internals, so a clean-room engine can be built against it. Every member is marked KEEP or INTERNAL; the panel DOM contract, the `.df-*` names the app still styles, `?render=`, and the event ordering are documented.
- **`lib/js/core/book.js`** adds `window.ZayaBook`, the single facade: `create`, `current`, `isReady`, `dispose`, and a handle carrying navigation, page mapping, search hooks, panels, chrome actions, sound, zoom and render mode. It is the only file in `lib/` that knows the engine's internals.
- **Every app call site migrated** to the facade: load.js (RTL and hard-cover reopen collapsed into one path; `ZayaBook.create` is the only constructor call), the controls, print, the Text tab, URL options and the test helpers. `window.dFlipBook` and `window.flipbookInstance` remain as deprecated aliases for one release.
- **`tests/engine-contract.spec.mjs`**: 11 engine-agnostic cases covering the facade surface, navigation and events, page mode and the pdf↔book mapping, RTL, panels, search, sound/zoom/resize, dispose and reopen without leaks, `?render=css`, hard cover and the aliases. The replacement engine must pass this file unchanged.
- `dispose()` now also strips the engine's classes and inline sizing from the container, which the fork never did.

## Checklist

- [x] `npm run check && npm run lint && npm test` pass locally (77/77: 66 existing, 11 contract)
- [x] Tested in headless Chromium desktop and Android emulation through the existing suite
- [x] No third-party code added
- [x] `CHANGELOG.md` updated under Unreleased; `docs/ARCHITECTURE.md` gains the facade rule