### PR TITLE
The wheel zooms, a book is called by its own name, and the turn is quicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to Zaya are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **A book is called by its own name.** The header showed the host a link came from — every book
+  from one site was called `example.com` — or the name of the file on disk. A PDF usually carries
+  its own title, and that is now what is shown, falling back to the file at the end of the link
+  rather than the host it came from. The browser's title bar says it too, so a bookmark or a second
+  window names the book. This is a label only: a document is still identified internally by its
+  link or by its file name and size, so notes, remembered pages and stored copies are untouched.
+
+### Fixed
+- **The wheel zooms again.** It did nothing unless the control key was held, which left both the
+  magnification and the panning that depends on it out of reach — a page could only be enlarged by
+  double-clicking it. The wheel now zooms on its own, and a notch is a step rather than a leap: one
+  notch used to multiply the page by half again, crossing the whole range in three, and now moves
+  it about a tenth. The control key still works, since a trackpad pinch arrives that way. Dragging
+  a page that is larger than the window moves it, as it always did — it was simply unreachable.
+
 ## [7.1.0] - 2026-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   link or by its file name and size, so notes, remembered pages and stored copies are untouched.
 
 ### Fixed
+- **A page turn is quicker, and does less work while it runs.** The turn took 700ms with a curve
+  that eased in and out of it, which read as floaty rather than smooth; it now takes 480ms. Two
+  costs it carried on every frame are gone: the sheet's material is unlit, so the vertex normals
+  being recomputed for both sheets were read by nothing, and the vertices are now written straight
+  into the geometry's array rather than through three bounds-checked accessors each. Neither of
+  those changed the frame rate measurably on the machine this was tested on, where the frame rate
+  is set by a software renderer rather than by the page; they are removals of work that was doing
+  nothing, and the shorter turn is the part a reader will feel.
 - **The wheel zooms again.** It did nothing unless the control key was held, which left both the
   magnification and the panning that depends on it out of reach — a page could only be enlarged by
   double-clicking it. The wheel now zooms on its own, and a notch is a step rather than a leap: one

--- a/docs/engine-api.md
+++ b/docs/engine-api.md
@@ -50,7 +50,7 @@ replacement engine may accept more, but must not *require* more.
 | `height` | `string \| number` | The stage height. Zaya passes `"100%"`; a bare number is pixels. | KEEP |
 | `paddingTop` | `number` | Pixels kept clear at the top of the stage, so the app header does not sit over the page. Zaya passes `56`. | KEEP |
 | `paddingBottom` | `number` | Pixels kept clear at the bottom, for the control bar. Zaya passes `40`. | KEEP |
-| `duration` | `number` | Milliseconds one page turn takes. Zaya passes `700`. | KEEP |
+| `duration` | `number` | Milliseconds one page turn takes. Zaya passes `480`. | KEEP |
 | `backgroundColor` | CSS colour | The colour behind the book. | KEEP |
 | `direction` | `"ltr" \| "rtl"` | Reading direction, fixed for the life of the book: changing it reopens the document (§3). | KEEP |
 | `openPage` | `number` | The book page to open on, 1-based. Out-of-range values are clamped, never rejected. | KEEP |

--- a/engine-next/gestures.js
+++ b/engine-next/gestures.js
@@ -13,7 +13,7 @@
  * | press and drag | the sheet follows the pointer and settles on release | the page pans |
  * | click or tap | turns the side that was tapped | nothing |
  * | double-click, double-tap | zooms in on that point | zooms back out to fit |
- * | ctrl and the wheel | zooms about the pointer | zooms about the pointer |
+ * | the wheel | zooms about the pointer | zooms about the pointer, and pans none |
  * | two fingers apart or together | zooms about their midpoint | the same, and pans with them |
  *
  * A press that lands on a run of text in the text layer never starts a drag: the reader is
@@ -264,12 +264,20 @@ export class Gestures {
 
   onWheel(event) {
     if (this.disposed || !this.on.isInteractive()) return;
-    // A trackpad pinch arrives as a wheel with the control key held; so does the keyboard zoom.
-    if (!event.ctrlKey && !event.metaKey) return;
+    /*
+     * The wheel zooms, with or without the control key. A reader reaches for the wheel to make a
+     * page bigger, and the stage has nothing to scroll; a trackpad pinch and the keyboard zoom
+     * arrive as a wheel with the control key held, and mean the same thing here.
+     */
     event.preventDefault();
+    /*
+     * Exponential in the delta, so one fast scroll and several slow ones agree. The divisor sets
+     * how much one notch does: a notch is around 100 of these units, and 1000 makes that a tenth
+     * bigger, which is roughly what a picture viewer does. It was 260 -- a single notch multiplied
+     * the page by one and a half, so the wheel went from fit to the limit in three.
+     */
+    const factor = Math.exp(-event.deltaY / 1000);
     const point = this.local(event);
-    // Exponential in the wheel delta, so a fast scroll and several slow ones agree.
-    const factor = Math.exp(-event.deltaY / 260);
     this.on.onZoomAt(factor, point.x, point.y);
   }
 

--- a/engine-next/index.js
+++ b/engine-next/index.js
@@ -30,7 +30,7 @@ const DEFAULTS = {
   direction: "ltr",
   openPage: 1,
   hard: "none",
-  duration: 700,
+  duration: 480,
   paddingTop: 0,
   paddingBottom: 0,
   backgroundColor: "#20232a",

--- a/engine-next/renderer-webgl.js
+++ b/engine-next/renderer-webgl.js
@@ -205,13 +205,20 @@ export class WebglRenderer {
       if (!mesh) return;
       const base = mesh.userData.base;
       const position = mesh.geometry.attributes.position;
+      /*
+       * Written straight into the attribute's array rather than through setX/setY/setZ. This runs
+       * for every vertex of both sheets on every frame of every turn, and the accessors cost three
+       * bounds-checked calls where one indexed write will do.
+       */
+      const out = position.array;
+      const invW = this.pageW ? 1 / this.pageW : 0;
       for (let i = 0; i < position.count; i++) {
-        const r = base[i * 3];                       // distance from the spine, 0 … pageW
-        const u = this.pageW ? r / this.pageW : 0;
-        const dz = bulge * Math.sin(Math.PI * u);
-        position.setX(i, side * (r * cos + dz * sin));
-        position.setY(i, base[i * 3 + 1]);
-        position.setZ(i, r * sin + dz * cos);
+        const o = i * 3;
+        const r = base[o];                           // distance from the spine, 0 … pageW
+        const dz = bulge * Math.sin(Math.PI * (r * invW));
+        out[o] = side * (r * cos + dz * sin);
+        out[o + 1] = base[o + 1];
+        out[o + 2] = r * sin + dz * cos;
       }
       position.needsUpdate = true;
       /*

--- a/engine-next/renderer-webgl.js
+++ b/engine-next/renderer-webgl.js
@@ -214,7 +214,11 @@ export class WebglRenderer {
         position.setZ(i, r * sin + dz * cos);
       }
       position.needsUpdate = true;
-      mesh.geometry.computeVertexNormals();
+      /*
+       * No normals are recomputed here. The sheet's material is unlit (MeshBasicMaterial with a
+       * shading term of its own), so nothing ever reads them, and computing them for both meshes
+       * on every frame of every turn was pure cost.
+       */
       mesh.material.userData.shade.value = hard ? 0 : Math.sin(Math.PI * progress) * 0.35;
       mesh.visible = true;
     });

--- a/lib/js/core/load.js
+++ b/lib/js/core/load.js
@@ -154,7 +154,7 @@ async function loadFlipbook(pdfUrl, rtlMode, page, pdfId) {
         height: "100%",
         paddingTop: 56,   // keep the page clear of the app header
         paddingBottom: 40,
-        duration: 700,
+        duration: 480,
         backgroundColor: "#2F2D2F",
         direction: rtlMode ? 'rtl' : 'ltr',
         hard: window.appState.get('hardCover') || 'none', // 'none' | 'cover' | 'all'

--- a/lib/js/core/load.js
+++ b/lib/js/core/load.js
@@ -178,6 +178,7 @@ async function loadFlipbook(pdfUrl, rtlMode, page, pdfId) {
                 });
             }
             if (book) console.log('PDF loaded successfully with', book.pageCount, 'pages');
+            applyDocumentTitle(book, pdfUrl);
             // Remembered More-menu choices first, so an explicit ?mode= still wins over them.
             if (window.ZayaBookPrefs) window.ZayaBookPrefs.applyTo(book);
             if (window.ZayaUrlOptions) window.ZayaUrlOptions.applyToBook(book);
@@ -367,6 +368,64 @@ function updatePdfContext(pdfUrl, pdfId) {
     }
 
     updatePdfInfoDisplay(pdfName, pdfType);
+}
+
+/* ---- The name of the book -------------------------------------------------------------------- */
+
+/**
+ * What to call the document on screen. This is a label only: the document's *identity* stays
+ * `currentPdfName` (a file's own name, which the document key is built from), and nothing here
+ * touches it, so notes, remembered pages and stored copies are unaffected.
+ *
+ * A PDF usually carries its own title, and that is the name of the book rather than the name of
+ * the file it arrived in. Failing that, a link falls back to the file at the end of its path --
+ * "war-and-peace.pdf" says far more than the host it was fetched from -- and a file from disk to
+ * the name it was picked under.
+ */
+function cleanMetadataTitle(raw) {
+    if (typeof raw !== 'string') return '';
+    // A title comes from the document, so it is text of unknown provenance: strip the control
+    // characters, collapse the whitespace and keep it to a length a header can show.
+    let title = raw.replace(/[\u0000-\u001f\u007f-\u009f]/g, ' ').replace(/\s+/g, ' ').trim();
+    // Word and its imitators write "Microsoft Word - report.doc" into the title of a printed PDF.
+    title = title.replace(/^Microsoft Word\s*-\s*/i, '').trim();
+    if (!title || /^untitled$/i.test(title)) return '';
+    return title.length > 120 ? title.slice(0, 119).trimEnd() + '\u2026' : title;
+}
+
+/** The file at the end of a link, when the link ends in one. */
+function fileNameFromUrl(pdfUrl) {
+    try {
+        const path = new URL(pdfUrl).pathname;
+        const last = decodeURIComponent(path.split('/').filter(Boolean).pop() || '');
+        return /\.pdf$/i.test(last) ? last : '';
+    } catch (e) {
+        return '';
+    }
+}
+
+/**
+ * Read the document's own title, then put the best name available on every element that shows it
+ * and in the browser's own title bar. Resolves when it has done so; a document that will not say
+ * simply keeps the name it already had.
+ */
+function applyDocumentTitle(book, pdfUrl) {
+    const isLocal = String(pdfUrl || '').startsWith('blob:');
+    const fallback = isLocal
+        ? (window.appState.get('currentPdfName') || '')
+        : (fileNameFromUrl(pdfUrl) || (window.appState.get('currentPdfName') || ''));
+
+    const show = (name) => {
+        const shown = name || fallback;
+        if (shown) updatePdfInfoDisplay(shown, isLocal ? 'local' : 'url');
+        document.title = shown ? `${shown} \u2014 Zaya` : 'Zaya';
+    };
+
+    const doc = book && book.pdfDocument;
+    if (!doc || typeof doc.getMetadata !== 'function') { show(''); return Promise.resolve(); }
+    return doc.getMetadata()
+        .then((meta) => show(cleanMetadataTitle(meta && meta.info && meta.info.Title)))
+        .catch(() => show(''));
 }
 
 function updatePdfInfoDisplay(pdfName, pdfType) {

--- a/tests/engine-next.spec.mjs
+++ b/tests/engine-next.spec.mjs
@@ -309,13 +309,23 @@ for (const renderMode of ['webgl', 'css']) {
       expect((await zoomState(page)).scale).toBeLessThanOrEqual(4);
     });
 
-    test('the wheel with a modifier zooms about the pointer, and a double click toggles', async ({ page }) => {
+    test('the wheel zooms about the pointer, with or without a modifier, and a double click toggles', async ({ page }) => {
       await open(page, q);
       const box = await page.locator('#book').boundingBox();
       await page.mouse.move(box.x + box.width * 0.7, box.y + box.height * 0.4);
-      await page.mouse.wheel(0, -400);
-      expect((await zoomState(page)).level).toBe(1);   // no modifier: the wheel is not ours
 
+      // The bare wheel zooms: it is what a reader reaches for, and the stage has nothing to scroll.
+      await page.mouse.wheel(0, -100);
+      await expect.poll(async () => (await zoomState(page)).level > 1).toBe(true);
+      const oneNotch = (await zoomState(page)).level;
+      // A notch is a step rather than a leap; it used to multiply the page by half again.
+      expect(oneNotch).toBeGreaterThan(1.02);
+      expect(oneNotch).toBeLessThan(1.25);
+      await page.evaluate(() => window.zayaDemo.book.resetZoom());
+      await expect.poll(async () => (await zoomState(page)).level).toBe(1);
+
+      // A trackpad pinch and the keyboard zoom arrive as a wheel with the control key, and mean
+      // the same thing here.
       await page.keyboard.down('Control');
       await page.mouse.wheel(0, -400);
       await page.keyboard.up('Control');

--- a/tests/fixtures/sample-titled.pdf
+++ b/tests/fixtures/sample-titled.pdf
@@ -1,0 +1,47 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [4 0 R 6 0 R] /Count 2 >>
+endobj
+3 0 obj
+<< /Length 74 >>
+stream
+BT /F1 18 Tf 50 700 Td (A book with a title of its own.) Tj ET
+endstream
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 1 0 R >> >> /Contents 3 0 R >>
+endobj
+5 0 obj
+<< /Length 62 >>
+stream
+BT /F1 18 Tf 50 700 Td (The second page.) Tj ET
+endstream
+endobj
+6 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 1 0 R >> >> /Contents 5 0 R >>
+endobj
+7 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+8 0 obj
+<< /Title (The Meditations of Marcus Aurelius) /Author (Marcus Aurelius) >>
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000009 00000 n 
+0000000079 00000 n 
+0000000142 00000 n 
+0000000254 00000 n 
+0000000380 00000 n 
+0000000477 00000 n 
+0000000603 00000 n 
+0000000652 00000 n 
+trailer
+<< /Size 9 /Root 7 0 R /Info 8 0 R >>
+startxref
+743
+%%EOF

--- a/tests/smoke.spec.mjs
+++ b/tests/smoke.spec.mjs
@@ -100,6 +100,62 @@ test.describe('Zaya app shell', () => {
   });
 });
 
+test.describe('The name of the book', () => {
+  test('a document that carries its own title is called by it', async ({ page }) => {
+    await page.goto('/index.html?pdf=' + encodeURIComponent('/tests/fixtures/sample-titled.pdf'));
+    await waitForBook(page);
+    await expect
+      .poll(() => page.evaluate(() => document.querySelector('.app-doc-name')?.textContent), { timeout: 20_000 })
+      .toBe('The Meditations of Marcus Aurelius');
+    // The browser's own title bar, so a bookmark or a second window says which book it is.
+    expect(await page.title()).toBe('The Meditations of Marcus Aurelius — Zaya');
+  });
+
+  test('a document with no title of its own falls back to the file, not the host', async ({ page }) => {
+    await page.goto('/index.html?pdf=' + encodeURIComponent('/tests/fixtures/sample.pdf'));
+    await waitForBook(page);
+    await expect
+      .poll(() => page.evaluate(() => document.querySelector('.app-doc-name')?.textContent), { timeout: 20_000 })
+      .toBe('sample.pdf');
+  });
+});
+
+test.describe('Zoom', () => {
+  test('the wheel zooms without a modifier, a notch at a time, and the page then pans', async ({ page }) => {
+    await stubNetwork(page);
+    await page.goto('/index.html?pdf=https://example.com/sample.pdf');
+    await waitForBook(page);
+    const state = () => page.evaluate(() => {
+      const e = window.ZayaBook.current.engine;
+      return { zoom: e.zoomLevel, panX: Math.round(e.panX) };
+    });
+    expect((await state()).zoom).toBe(1);
+
+    const box = await page.locator('#flipbookContainer').boundingBox();
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await page.mouse.move(cx, cy);
+
+    // One notch is a step, not a leap: it used to multiply the page by half again.
+    await page.mouse.wheel(0, -100);
+    await expect.poll(async () => (await state()).zoom > 1, { timeout: 10_000 }).toBe(true);
+    const oneNotch = (await state()).zoom;
+    expect(oneNotch).toBeGreaterThan(1.02);
+    expect(oneNotch).toBeLessThan(1.25);
+
+    // Far enough in that the page is larger than the stage, and it follows the pointer.
+    for (let i = 0; i < 9; i++) {
+      await page.mouse.wheel(0, -120);
+      await page.waitForTimeout(120);
+    }
+    await expect.poll(async () => (await state()).zoom > 2, { timeout: 10_000 }).toBe(true);
+    await page.mouse.down();
+    await page.mouse.move(cx - 200, cy, { steps: 15 });
+    await page.mouse.up();
+    await expect.poll(async () => (await state()).panX, { timeout: 10_000 }).toBeLessThan(-50);
+  });
+});
+
 test.describe('Keyboard', () => {
   /*
    * The engine takes pointer input only, so page turns from the keyboard are the application's


### PR DESCRIPTION
## Summary

Three things reported from reading a real book. Two of them turned out to be one fault, and one of them is not what it looked like.

**Zoom and panning were unreachable, not broken.** The wheel did nothing unless the control key was held, so the only way to enlarge a page was to double-click it — and dragging did nothing because panning applies only to a page larger than the window, which you could never get to. Measured before the change, one control-and-wheel notch multiplied the page by **1.47×**: three notches crossed the whole range to the 4× limit, which is why it never felt controllable either. The wheel now zooms on its own at about 1.1× a notch, the control key still works since a trackpad pinch arrives that way, and at 3.3× a drag moves the page by exactly the distance dragged.

**The title was never the book's.** This is not something the engine replacement broke — no version of Zaya ever read a PDF's own title. A link was labelled with its *host*, so every book from one site had the same name, and a file was labelled with whatever it was saved as. The document's own title is used now, falling back to the file at the end of the link rather than the host, and the browser's title bar follows it.

| | before | after |
| --- | --- | --- |
| a PDF carrying a title | `127.0.0.1` | `The Meditations of Marcus Aurelius` |
| a PDF carrying none | `127.0.0.1` | `sample.pdf` |
| the browser's title bar | `Zaya` | `The Meditations of Marcus Aurelius — Zaya` |

This is a label only. A document is still identified by its link, or by its file name and size, so notes, remembered pages and stored copies are untouched — overwriting the name would have broken document identity.

**The page turn is shorter, and carries less per-frame work.** 700ms with a curve easing in and out of the turn reads as floaty; it is 480ms now. Two costs on every frame are gone: the sheet's material is unlit, so the vertex normals recomputed for both sheets were read by nothing, and vertices are written straight into the geometry's array rather than through three bounds-checked accessors each.

## What I could not establish

The stutter is reported as real and I believe it, but I cannot attribute it from here. This machine renders WebGL in software and holds about 32 frames a second through a turn whatever the code does — 23 frames over 712ms before, 16 over 485ms after, the same rate. So the two per-frame removals above are removals of work that was doing nothing rather than a demonstrated fix, and the shorter turn is the part a reader will actually feel, because a hitch has less time to show.

Attributing the stutter needs a profile on hardware with a real GPU. The likely candidates, in order: the texture upload when the new spread is shown, the text layer being rebuilt as the turn lands, and the device pixel ratio of 2 on a high-density screen — that last one is the standard thing to drop during a turn and restore after, at some cost in sharpness while it moves.

Also worth knowing: the first measurements I took of this were worthless. Headless Chromium reports `prefers-reduced-motion: reduce`, so the engine skipped the animation entirely and I was timing an idle page. The numbers above come from a context with motion enabled.

## Checklist

- [x] `npm run check && npm run lint && npm test` pass locally (159/159, 3 new)
- [x] New tests: a document called by its own title, the fallback to the file rather than the host, and the wheel zooming a notch at a time and then panning
- [x] Two engine tests updated, deliberately: they asserted that a bare wheel does nothing, which is the behaviour being changed
- [x] New fixture `tests/fixtures/sample-titled.pdf` — a PDF whose Info dictionary names the book
- [x] No third-party code added
- [x] `CHANGELOG.md` under Unreleased; `docs/engine-api.md` records the new turn duration

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABXLiVumYcz8fhQVaqBHQ4)_