### PR TITLE
The book can be tipped away from flat again, and the contract says what a reader can do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   link or by its file name and size, so notes, remembered pages and stored copies are untouched.
 
 ### Fixed
+- **The book can be tipped away from flat again.** Holding shift and dragging — or dragging with
+  the right button — carries the view around the book, so a page can be looked along at an angle
+  rather than only face on; shift and a double click lays it flat. This was in Zaya until 7.0.0 and
+  went missing in the engine replacement. It needs a gesture of its own because an ordinary drag
+  anywhere on the stage turns a page, including the space beside the book, which is exactly where a
+  reader reaches to flick a corner. Tipping works in both renderers, and the whole book stays in
+  view at any angle. `docs/engine-api.md` now records it as part of the contract, with a note on
+  how it came to be lost, so that a future engine cannot quietly drop it.
 - **A page turn is quicker, and does less work while it runs.** The turn took 700ms with a curve
   that eased in and out of it, which read as floaty rather than smooth; it now takes 480ms. Two
   costs it carried on every frame are gone: the sheet's material is unlit, so the vertex normals

--- a/docs/engine-api.md
+++ b/docs/engine-api.md
@@ -322,6 +322,37 @@ Zaya also emits `zaya:themeChanged`, `zaya:languageChanged`, `zaya:pageTextChang
 
 ---
 
+## 9a. What the reader can do to the stage
+
+Every row below is part of the contract, exactly as the members above are. They are listed
+separately because they are the ones easiest to lose: none of them has a call site in the
+application, so an engine rebuilt from this document's member tables alone would satisfy every
+test and still take them away. Three were in fact lost in 7.0.0 and restored afterwards — the
+wheel, panning, and tipping the book.
+
+| Gesture | At rest | Magnified |
+| --- | --- | --- |
+| click or tap | turns the side that was clicked | nothing |
+| press and drag | the sheet follows the pointer and settles by where it was let go | the page pans |
+| the wheel | zooms about the pointer, a notch at a time | the same |
+| control and the wheel | the same — it is how a trackpad pinch and the keyboard zoom arrive | the same |
+| two fingers apart or together | zooms about their midpoint | the same, and pans with them |
+| double-click or double-tap | zooms in on that point | back to fit |
+| shift and drag, or the right button | tips the book away from flat | the same |
+| shift and double-click | lays a tipped book flat | the same |
+| a press on a run of text | selects it, and never turns a page | the same |
+
+Two rules behind the table. A gesture on the book and a gesture beside it do the same thing: the
+space around a page is where a reader reaches to flick its corner, so it cannot be given to
+anything else. And a magnified page keeps its own gestures — panning replaces the page turn while
+it is magnified, rather than the two competing.
+
+Keyboard navigation is the application's, not the engine's: arrow keys, `Home` and `End` are bound
+in `lib/js/ui/controls.js`. What the engine owes is not to swallow them — a text layer that takes
+the arrow keys for its own is a defect.
+
+---
+
 ## 10. What the engine may not do
 
 An engine reads and writes nothing outside its own container and its own construction options.

--- a/docs/engine-api.md
+++ b/docs/engine-api.md
@@ -252,9 +252,28 @@ contract: the `zoomChange` option fires **once** on each crossing of the fit bou
 once per step; a magnified page is re-rendered at the magnified scale rather than merely
 stretched; and the reader can pan a magnified page and get back to fit.
 
+| `tilt` | getter → `{pitch, yaw, tilted}` | How far the book is tipped away from flat, in radians: `pitch` above or below it, `yaw` to one side. `tilted` is false when it lies flat. | control bar | KEEP |
+| `setTilt(pitch, yaw)` | `(number, number) → tilt` | Tip the book. An engine clamps the angles to what stays readable and returns what it applied, so a caller can follow. | control bar | KEEP |
+| `resetTilt()` | `() → tilt` | Lay it flat again. | control bar | KEEP |
+
+The reader tips the book by holding shift and dragging, or by dragging with the right button, and
+lays it flat again with shift and a double click. It needs a gesture of its own because an ordinary
+drag anywhere on the stage turns a page — including the space beside the book, which is where a
+reader reaches to flick a corner. An engine that cannot tip a book keeps these members and reports
+a flat one.
+
+> **Why this is written down.** This capability was lost in 7.0.0 and restored in the release after
+> it. The first version of this contract recorded only `book.stage.orbitControl.enabled` under the
+> internal members below, because the application's sole use of the old engine's orbit control was
+> to switch it *off* while the pointer was over a drawer. Read from the call sites alone it looked
+> like plumbing; it was in fact the only way a reader could tip the book, and freezing the contract
+> from what the application called rather than from what the reader could do let it fall out of the
+> rebuild unnoticed. A capability with no call site is exactly the kind this document exists to
+> protect.
+
 **INTERNAL, migrated away:** `book.ui.switchFullscreen`, `book.ui.share`, `book.ui.download`,
 `book.ui.updateSound`, `book.options.soundEnable`, `book.options.source`,
-`book.stage.orbitControl.enabled`.
+`book.stage.orbitControl.enabled` (its *capability* is now the `tilt` members above).
 
 ---
 

--- a/engine-next/gestures.js
+++ b/engine-next/gestures.js
@@ -11,8 +11,10 @@
  * | gesture | at rest | zoomed in |
  * | --- | --- | --- |
  * | press and drag | the sheet follows the pointer and settles on release | the page pans |
+ * | shift and drag, or the right button | tips the book away from flat | the same |
  * | click or tap | turns the side that was tapped | nothing |
  * | double-click, double-tap | zooms in on that point | zooms back out to fit |
+ * | shift and double-click | lays a tipped book flat again | the same |
  * | the wheel | zooms about the pointer | zooms about the pointer, and pans none |
  * | two fingers apart or together | zooms about their midpoint | the same, and pans with them |
  *
@@ -21,6 +23,15 @@
  * selected nothing and moved nowhere, it is treated as a tap after all, so a page can still be
  * turned by clicking the middle of a paragraph.
  */
+
+/**
+ * A drag that tips the book rather than turning a page. It needs a gesture of its own: dragging
+ * anywhere on the stage turns pages, including the space beside the book, which is exactly where a
+ * reader reaches to flick a corner. Shift works with any pointer; the right button suits a mouse.
+ */
+function isOrbitGesture(event) {
+  return !!(event.shiftKey || (event.pointerType === "mouse" && event.button === 2));
+}
 
 /** How far across the stage a drag must travel for the turn to be complete. */
 const DRAG_SPAN = 0.5;
@@ -72,6 +83,8 @@ export class Gestures {
     stage.addEventListener("pointercancel", this.onPointerUp);
     stage.addEventListener("wheel", this.onWheel, { passive: false });
     stage.addEventListener("dblclick", this.onDoubleClick);
+    this.onContextMenu = (event) => { if (this.drag && this.drag.orbit) event.preventDefault(); };
+    stage.addEventListener("contextmenu", this.onContextMenu);
   }
 
   /** Pointer position relative to the stage. */
@@ -94,7 +107,7 @@ export class Gestures {
 
   onPointerDown(event) {
     if (this.disposed || !this.on.isInteractive()) return;
-    if (event.pointerType === "mouse" && event.button !== 0) return;
+    if (event.pointerType === "mouse" && event.button !== 0 && !isOrbitGesture(event)) return;
     this.cancelPendingTap();
     const point = this.local(event);
     this.pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
@@ -118,6 +131,8 @@ export class Gestures {
       width: point.width,
       forward: this.forwardSide(point.x / point.width),
       onText,
+      // Shift, or the right button, means the reader is tipping the book rather than turning it.
+      orbit: !onText && isOrbitGesture(event),
       moved: false,
       preview: null,
       progress: 0,
@@ -153,6 +168,15 @@ export class Gestures {
     const dy = event.clientY - drag.startY;
     if (!drag.moved && Math.hypot(dx, dy) < DRAG_SLOP) return;
     drag.moved = true;
+
+    if (drag.orbit && !this.on.isZoomed()) {
+      if (typeof this.on.onOrbit === "function") {
+        this.on.onOrbit(event.clientX - drag.lastX, event.clientY - drag.lastY);
+      }
+      drag.lastX = event.clientX;
+      drag.lastY = event.clientY;
+      return;
+    }
 
     if (this.on.isZoomed()) {
       this.on.onPan(event.clientX - drag.lastX, event.clientY - drag.lastY);
@@ -287,6 +311,8 @@ export class Gestures {
     const selection = typeof window.getSelection === "function" ? window.getSelection() : null;
     if (selection && !selection.isCollapsed) return;   // a double-click selected a word
     const point = this.local(event);
+    // Shift and a double click lays a tipped book flat, as shift and a drag tipped it.
+    if (event.shiftKey && typeof this.on.onOrbitReset === "function") { this.on.onOrbitReset(); return; }
     this.on.onDoubleTap(point.x, point.y);
   }
 
@@ -299,6 +325,7 @@ export class Gestures {
     this.stage.removeEventListener("pointercancel", this.onPointerUp);
     this.stage.removeEventListener("wheel", this.onWheel);
     this.stage.removeEventListener("dblclick", this.onDoubleClick);
+    this.stage.removeEventListener("contextmenu", this.onContextMenu);
     this.pointers.clear();
   }
 }

--- a/engine-next/index.js
+++ b/engine-next/index.js
@@ -131,6 +131,9 @@ export class ZayaBook {
     this.turnToken = 0;
     this.interactive = true;
     this.zoomLevel = 1;
+    // How far the book is tipped away from flat, in radians. Flat until the reader tips it.
+    this.tiltPitch = 0;
+    this.tiltYaw = 0;
     this.panX = 0;
     this.panY = 0;
     this.dragTurn = null;
@@ -615,6 +618,42 @@ export class ZayaBook {
 
   zoomOut() { return this.zoom(this.zoomLevel / ZOOM_STEP); }
 
+  /* ---- tilt ------------------------------------------------------------------------------- */
+
+  /**
+   * Tip the book by a drag, in pixels. A drag across the whole stage turns it about as far as it
+   * will go, so the book follows the hand at a rate that suits the size of the window.
+   */
+  tiltBy(dx, dy) {
+    const perPixel = Math.PI / Math.max(320, this.stage.clientWidth);
+    return this.setTilt(this.tiltPitch + dy * perPixel, this.tiltYaw + dx * perPixel);
+  }
+
+  /** Set the angle outright. Radians; the renderer clamps them to what stays readable. */
+  setTilt(pitch, yaw) {
+    if (!this.renderer || typeof this.renderer.setTilt !== "function") return this.tilt;
+    const applied = this.renderer.setTilt(pitch, yaw) || { pitch: 0, yaw: 0 };
+    this.tiltPitch = applied.pitch;
+    this.tiltYaw = applied.yaw;
+    this.announceTilt();
+    return this.tilt;
+  }
+
+  /** Lay the book flat again. */
+  resetTilt() {
+    return this.setTilt(0, 0);
+  }
+
+  get tilt() {
+    return { pitch: this.tiltPitch, yaw: this.tiltYaw, tilted: !!(this.tiltPitch || this.tiltYaw) };
+  }
+
+  announceTilt() {
+    const detail = this.tilt;
+    emit("zaya-engine:tiltChanged", detail);
+    if (typeof this.options.tiltChange === "function") this.options.tiltChange(detail);
+  }
+
   resetZoom() {
     if (!this.renderer) return MIN_ZOOM;
     const before = this.zoomed;
@@ -905,6 +944,8 @@ export class ZayaBook {
         if (this.zoomed) this.resetZoom();
         else this.zoom(DOUBLE_TAP_ZOOM, { about: { x, y } });
       },
+      onOrbit: (dx, dy) => this.tiltBy(dx, dy),
+      onOrbitReset: () => this.resetTilt(),
     });
   }
 

--- a/engine-next/renderer-css.js
+++ b/engine-next/renderer-css.js
@@ -36,6 +36,7 @@ export class CssRenderer {
     this.pageH = 1;
     this.frame = 0;
     this.zoom = { level: 1, x: 0, y: 0 };
+    this.tilt = { pitch: 0, yaw: 0 };
 
     this.spread = element("zn-spread");
     this.left = element("zn-page zn-page-left");
@@ -129,11 +130,28 @@ export class CssRenderer {
     this.applyZoom();
   }
 
+  /**
+   * Tip the book away from flat. There is no camera here, so the same intention is expressed as a
+   * rotation of the spread in the browser's own perspective: the reader gets the same picture by a
+   * different route, rather than the tilt being a thing only the 3D renderer can do.
+   */
+  setTilt(pitch, yaw) {
+    this.tilt = { pitch: pitch || 0, yaw: yaw || 0 };
+    this.applyZoom();
+    return this.tilt;
+  }
+
   applyZoom() {
     const { level, x, y } = this.zoom;
+    const { pitch, yaw } = this.tilt || { pitch: 0, yaw: 0 };
     this.spread.style.transformOrigin = "50% 50%";
-    this.spread.style.transform = level === 1 && !x && !y
-      ? "" : `translate(${x}px, ${y}px) scale(${level})`;
+    const flat = level === 1 && !x && !y && !pitch && !yaw;
+    // A positive pitch looks down on the book, which is the page leaning away at its top edge.
+    const turn = pitch || yaw
+      ? ` rotateX(${(pitch * 180) / Math.PI}deg) rotateY(${(-yaw * 180) / Math.PI}deg)`
+      : "";
+    this.spread.style.transform = flat
+      ? "" : `translate(${x}px, ${y}px) scale(${level})${turn}`;
   }
 
   /** The point a zoom happens about: the middle of the spread as it is laid out. */

--- a/engine-next/renderer-webgl.js
+++ b/engine-next/renderer-webgl.js
@@ -20,6 +20,12 @@ import * as THREE from "../vendor/three/three.module.min.js";
 const FOV = 32;
 /** Segments across the sheet. Enough that the curl reads as a curve rather than a fold. */
 const SEGMENTS = 28;
+/*
+ * How far the book can be turned away from flat. Far enough to look along the page the way you
+ * would tip a real book towards a lamp, and not so far that it is edge-on and unreadable.
+ */
+const MAX_PITCH = (60 * Math.PI) / 180;
+const MAX_YAW = (45 * Math.PI) / 180;
 /** How far the paper bulges out of plane, as a fraction of the page width. */
 const CURL = 0.16;
 
@@ -80,6 +86,8 @@ export class WebglRenderer {
 
     this.scene = new THREE.Scene();
     this.camera = new THREE.PerspectiveCamera(FOV, 1, 0.05, 200);
+    // How far the lens has been carried around the book: flat on, until the reader says otherwise.
+    this.tilt = { pitch: 0, yaw: 0 };
     this.setBackground(book.options.backgroundColor);
 
     this.pageW = 0.72;                 // world units; corrected as soon as a page is measured
@@ -259,7 +267,7 @@ export class WebglRenderer {
     const worldPerPixel = (2 * dist * Math.tan(halfFov)) / height;
     const offset = (padTop + usable / 2 - height / 2) * worldPerPixel;
 
-    this.fit = { distance: dist, offset, worldPerPixel };
+    this.fit = { distance: dist, offset, worldPerPixel, spreadW, spreadH };
     this.placeCamera();
   }
 
@@ -276,6 +284,21 @@ export class WebglRenderer {
     this.placeCamera();
   }
 
+  /**
+   * Carry the lens around the book. Angles are radians and are clamped, so a reader who keeps
+   * dragging stops at a useful angle rather than looking at the spine edge-on.
+   * @param {number} pitch above (positive) or below the book
+   * @param {number} yaw to one side or the other
+   */
+  setTilt(pitch, yaw) {
+    this.tilt = {
+      pitch: Math.max(-MAX_PITCH, Math.min(MAX_PITCH, pitch || 0)),
+      yaw: Math.max(-MAX_YAW, Math.min(MAX_YAW, yaw || 0)),
+    };
+    this.placeCamera();
+    return this.tilt;
+  }
+
   placeCamera() {
     if (this.disposed) return;
     const { distance, offset, worldPerPixel } = this.fit;
@@ -285,7 +308,27 @@ export class WebglRenderer {
     const perPixel = worldPerPixel / level;
     const cx = -this.zoom.x * perPixel;
     const cy = offset + this.zoom.y * perPixel;
-    this.camera.position.set(cx, cy, distance / level);
+    /*
+     * The lens rides on a sphere around the point it is looking at, so tilting carries it up and
+     * over the book rather than sliding the book about. At a pitch and yaw of zero this is exactly
+     * the straight-on placement it replaces: (cx, cy, distance / level), looking at (cx, cy, 0).
+     */
+    const { pitch, yaw } = this.tilt;
+    /*
+     * Tipping the book brings its nearest corner towards the lens, and with a perspective lens that
+     * corner grows and runs off the top or the side of the stage. Backing off by exactly how far
+     * that corner came forward keeps the whole book in view at any angle; at zero tilt it adds
+     * nothing, so a flat book is framed exactly as before.
+     */
+    const nearer = (this.fit.spreadW / 2) * Math.abs(Math.sin(yaw))
+      + (this.fit.spreadH / 2) * Math.abs(Math.sin(pitch));
+    const radius = (distance + nearer) / level;
+    const cosPitch = Math.cos(pitch);
+    this.camera.position.set(
+      cx + radius * Math.sin(yaw) * cosPitch,
+      cy + radius * Math.sin(pitch),
+      radius * Math.cos(yaw) * cosPitch,
+    );
     this.camera.lookAt(cx, cy, 0);
     this.camera.updateProjectionMatrix();
     this.requestRender();

--- a/lib/js/core/book.js
+++ b/lib/js/core/book.js
@@ -278,6 +278,22 @@
             if (Number(delta) < 0) b.zoomOut();
             else b.zoomIn();
         };
+        /**
+         * How far the book is tipped away from flat, in radians, and how to tip it. A reader does
+         * this by dragging beside the book; this is here so the interface can offer it too, and so
+         * that it is part of the contract rather than something an engine may quietly drop.
+         */
+        Object.defineProperty(self, "tilt", {
+            get: () => {
+                const b = book();
+                const t = b && b.tilt;
+                return t ? { pitch: t.pitch, yaw: t.yaw, tilted: !!t.tilted }
+                    : { pitch: 0, yaw: 0, tilted: false };
+            }
+        });
+        self.setTilt = (pitch, yaw) => { const b = book(); if (b && b.setTilt) b.setTilt(pitch, yaw); return self.tilt; };
+        self.resetTilt = () => { const b = book(); if (b && b.resetTilt) b.resetTilt(); return self.tilt; };
+
         self.resize = () => { const b = book(); if (b) b.resize(); };
         /** Let go of the stage while the pointer is over app chrome that sits above it. */
         self.setInteractive = (on) => { const b = book(); if (b) b.setInteractive(!!on); };

--- a/tests/smoke.spec.mjs
+++ b/tests/smoke.spec.mjs
@@ -156,6 +156,50 @@ test.describe('Zoom', () => {
   });
 });
 
+test.describe('Tilting the book', () => {
+  /*
+   * Lost in 7.0.0 and restored after it: the reader can tip the book away from flat. Held here
+   * rather than only in the engine's own tests, because what matters is that a reader can do it.
+   */
+  test('shift and a drag tips it, an ordinary drag still turns the page', async ({ page }) => {
+    await stubNetwork(page);
+    await page.goto('/index.html?pdf=https://example.com/sample.pdf');
+    await waitForBook(page);
+    const tilt = () => page.evaluate(() => window.ZayaBook.current.tilt);
+    expect(await tilt()).toEqual({ pitch: 0, yaw: 0, tilted: false });
+
+    const box = await page.locator('#flipbookContainer').boundingBox();
+    const y = box.y + box.height / 2;
+    /*
+     * Tipping needs a gesture of its own: an ordinary drag anywhere on the stage turns a page,
+     * including the space beside the book, which is where a reader reaches to flick a corner.
+     */
+    await page.keyboard.down('Shift');
+    await page.mouse.move(box.x + box.width * 0.5, y);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width * 0.5 + 130, y - 90, { steps: 14 });
+    await page.mouse.up();
+    await page.keyboard.up('Shift');
+    await expect.poll(async () => (await tilt()).tilted, { timeout: 10_000 }).toBe(true);
+    const tipped = await tilt();
+    expect(tipped.yaw).toBeGreaterThan(0);      // dragged to the right
+    expect(tipped.pitch).toBeLessThan(0);       // and upwards
+
+    // Dragging on the book still turns its pages rather than tipping it.
+    const before = await activePage(page);
+    await page.mouse.move(box.x + box.width * 0.75, y);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width * 0.3, y, { steps: 16 });
+    await page.mouse.up();
+    await expect.poll(() => activePage(page), { timeout: 15_000 }).not.toBe(before);
+
+    await page.keyboard.down('Shift');
+    await page.mouse.dblclick(box.x + box.width * 0.5, y);
+    await page.keyboard.up('Shift');
+    await expect.poll(async () => (await tilt()).tilted, { timeout: 10_000 }).toBe(false);
+  });
+});
+
 test.describe('Keyboard', () => {
   /*
    * The engine takes pointer input only, so page turns from the keyboard are the application's


### PR DESCRIPTION
## Summary

Tipping the book to look along a page at an angle was in Zaya until 7.0.0 and went missing in the engine replacement. It is back — and this also carries the audit that finds out whether anything else went with it.

**How it was lost.** When the contract was frozen in step E1, the old engine's orbit control was written down as `book.stage.orbitControl.enabled` under *INTERNAL, migrated away* — because the only thing the application ever did with it was switch it **off** while the pointer was over a drawer. Read from the call sites alone it looked like plumbing. It was in fact the only way a reader could tip the book. Freezing the contract from what the application *called* rather than from what the reader could *do* let the capability fall out of the rebuild unnoticed.

**How it works.** The lens rides on a sphere around the point it looks at, so tipping carries it over the book rather than sliding the book about; at zero angle the placement reduces to exactly the straight-on one it replaces. Tipping brings the book's nearest corner towards the lens, where a perspective camera pushes it off the top of the stage — so the camera backs off by precisely how far that corner came forward, and the whole book stays in view at any angle. That fault was caught by looking at a screenshot, not by any number. The plain-DOM renderer expresses the same intention as a rotation in the browser's own perspective, so tipping is not something only the 3D renderer can do. Angles are clamped to 60° of pitch and 45° of yaw.

**The gesture, and a wrong turn worth mentioning.** It is **shift and a drag**, or a drag with the **right button**; **shift and a double click** lays it flat. My first attempt gave it the empty space beside the book instead. Six existing drag tests failed immediately: they turn pages by dragging from near the edge of the stage, which is exactly where a reader reaches to flick a corner. A capability worth restoring is not worth taking page turning away for.

## The audit

Four reader-facing behaviours have now come back one at a time — the wheel zoom, panning, the document title, and tipping. Three of the four share the cause above, so rather than wait for a fifth, I checked the rest:

| Check | Result |
| --- | --- |
| control ids in `index.html` against 6.3.0 | none lost |
| translated strings against 6.3.0 | none lost |
| every member the contract marks KEEP, present on the facade at runtime | all present |
| all eleven reader gestures, exercised in the reader | all work |
| scrolling the thumbnail panel does not zoom the book (issue #11) | still holds |

The gestures exercised: click either side to turn, drag to turn, the wheel to zoom, drag to pan a magnified page, double-click back to fit, shift-drag to tip, shift-double-click to flatten, the arrow keys, `End`, and selecting text on the page.

**Nothing else is missing.** The chrome was never at risk — it is the application's own markup, and the engine swap could not touch it. Everything lost was on the stage, where a reader acts directly and no call site records it.

So `docs/engine-api.md` gains a section, **What the reader can do to the stage**, listing those gestures as part of the contract with the two rules behind them: the space beside a page belongs to the same gesture as the page, and a magnified page keeps its own gestures rather than competing with the page turn. An engine rebuilt from the member tables alone would pass every test and still take these away; now it has to answer for them.

## Checklist

- [x] `npm run check && npm run lint && npm test` pass locally (160/160, 1 new)
- [x] Verified in both renderers in the reader: tipping, page turns still working on an ordinary drag, and flattening
- [x] Checked by eye as well as by number — screenshots flat and tipped, confirming the book stays framed
- [x] No third-party code added
- [x] `CHANGELOG.md` under Unreleased; `docs/engine-api.md` records the tilt and the reader's gestures

## Worth knowing

The tilt is a gesture and three facade members (`tilt`, `setTilt`, `resetTilt`); it is not offered anywhere in the interface yet. If you want a control, Settings is the obvious home and the facade is ready for it.