### PR TITLE
Zaya 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to Zaya are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [7.2.0] - 2026-09-07
+
+Four things a reader reaches for, three of which the engine replacement had quietly taken away.
+Zaya's own engine arrived in 7.0.0 and the reader has been finding the gaps since: the wheel no
+longer zoomed, a magnified page could not be moved, and the book could not be tipped away from
+flat. None of them were broken — each was simply out of reach, and the fourth, a book called by
+its own name, had never worked at all.
 
 ### Added
 - **A book is called by its own name.** The header showed the host a link came from — every book

--- a/changelog.html
+++ b/changelog.html
@@ -10,9 +10,9 @@
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <link rel="icon" type="image/svg+xml" href="assets/changelog.svg">
 
-  <link rel="stylesheet" href="vendor/css/fonts.css?v=7.1.0">
-  <link rel="stylesheet" href="lib/css/themes/themes.css?v=7.1.0">
-  <link rel="stylesheet" href="lib/css/page/changelog.css?v=7.1.0">
+  <link rel="stylesheet" href="vendor/css/fonts.css?v=7.2.0">
+  <link rel="stylesheet" href="lib/css/themes/themes.css?v=7.2.0">
+  <link rel="stylesheet" href="lib/css/page/changelog.css?v=7.2.0">
 </head>
 
 <body>
@@ -72,6 +72,6 @@
     </div>
   </footer>
 
-  <script src="lib/js/features/changelog/changelog.bundle.js?v=7.1.0"></script>
+  <script src="lib/js/features/changelog/changelog.bundle.js?v=7.2.0"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-zaya-version="7.1.0">
+<html lang="en" data-zaya-version="7.2.0">
 
 <head>
   <meta charset="utf-8">
@@ -17,16 +17,16 @@
   <link rel="preload" href="vendor/fonts/webfonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
 
   <!-- All third-party assets are vendored (see docs/THIRD_PARTY_NOTICES.md); no runtime CDN dependency -->
-  <link rel="stylesheet" href="vendor/css/tailwind.css?v=7.1.0">
-  <link rel="stylesheet" href="vendor/css/fontawesome.min.css?v=7.1.0">
-  <link rel="stylesheet" href="vendor/css/toastify.min.css?v=7.1.0">
-  <link rel="stylesheet" href="lib/css/style.css?v=7.1.0">
+  <link rel="stylesheet" href="vendor/css/tailwind.css?v=7.2.0">
+  <link rel="stylesheet" href="vendor/css/fontawesome.min.css?v=7.2.0">
+  <link rel="stylesheet" href="vendor/css/toastify.min.css?v=7.2.0">
+  <link rel="stylesheet" href="lib/css/style.css?v=7.2.0">
   <!-- App shell (header, drawers, tabs): loaded last so it wins by order, not by !important -->
-  <link rel="stylesheet" href="lib/css/page/shell.css?v=7.1.0">
-  <link rel="stylesheet" href="lib/css/page/storage.css?v=7.1.0">
-  <link rel="stylesheet" href="lib/css/page/text-pane.css?v=7.1.0">
+  <link rel="stylesheet" href="lib/css/page/shell.css?v=7.2.0">
+  <link rel="stylesheet" href="lib/css/page/storage.css?v=7.2.0">
+  <link rel="stylesheet" href="lib/css/page/text-pane.css?v=7.2.0">
   <!-- Print sheet: screen-invisible, and the only thing left on the page when printing -->
-  <link rel="stylesheet" href="lib/css/page/print.css?v=7.1.0">
+  <link rel="stylesheet" href="lib/css/page/print.css?v=7.2.0">
 
   <!-- Per-deployment settings (default PDF, etc.) live in config.js -->
   <script src="config.js"></script>
@@ -580,7 +580,7 @@
   </div>
 
   <!-- Main Application Entry Point -->
-  <script type="module" src="lib/js/app.js?v=7.1.0"></script>
+  <script type="module" src="lib/js/app.js?v=7.2.0"></script>
 
 </body>
 </html>

--- a/lib/js/app.js
+++ b/lib/js/app.js
@@ -2,7 +2,7 @@
 // Loads all scripts in dependency order. Load order is the only thing this file owns.
 
 // Bump on every release: it versions the static asset URLs (cache busting) and is shown in the UI.
-const ZAYA_VERSION = '7.1.0';
+const ZAYA_VERSION = '7.2.0';
 window.ZAYA_VERSION = ZAYA_VERSION;
 
 // Deploy guard: the HTML carries the release it was built with. If this script belongs to another

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zaya",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "private": true,
   "description": "Zaya – 3D PDF flipbook reader. Static site; this package only carries dev tooling.",
   "license": "MIT",

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@
  *  - Cache name carries the app version so a deploy invalidates the old cache on activate.
  */
 
-const VERSION = '7.1.0';
+const VERSION = '7.2.0';
 const CACHE_NAME = `zaya-assets-v${VERSION}`;
 const MAX_ENTRIES = 300;
 

--- a/tests/persistence.spec.mjs
+++ b/tests/persistence.spec.mjs
@@ -763,7 +763,7 @@ test.describe('Deploy guard', () => {
       // The guard reloads the page mid-flight; a fetch cut off by that navigation must not fail the test.
       try {
         const res = await route.fetch();
-        const html = (await res.text()).replace('data-zaya-version="7.1.0"', 'data-zaya-version="0.0.1"');
+        const html = (await res.text()).replace('data-zaya-version="7.2.0"', 'data-zaya-version="0.0.1"');
         await route.fulfill({ response: res, body: html, headers: { ...res.headers(), 'content-type': 'text/html' } });
       } catch (e) {
         try { await route.continue(); } catch (e2) { /* the request is gone */ }
@@ -773,7 +773,7 @@ test.describe('Deploy guard', () => {
     await page.goto('/index.html');
     // The guard reloads exactly once, then boots normally on the second pass.
     await expect.poll(() => page.evaluate(() => { try { return sessionStorage.getItem('zaya:reloaded-for'); } catch (e) { return null; } }).catch(() => null), { timeout: 15_000 }).toBe('0.0.1');
-    await expect(page.locator('#currentVersion')).toHaveText(/v7\.1\.0|Unreleased/, { timeout: 30_000 });
+    await expect(page.locator('#currentVersion')).toHaveText(/v7\.2\.0|Unreleased/, { timeout: 30_000 });
     const cacheNames = await page.evaluate(async () => ('caches' in window) ? (await caches.keys()).filter((k) => k.startsWith('zaya-')) : []);
     // Only the freshly (re)installed worker's cache may exist; nothing from before the reload.
     expect(cacheNames.length).toBeLessThanOrEqual(1);


### PR DESCRIPTION
## Summary

The four entries sitting under `## [Unreleased]` become a release. No code changes — the version and the changelog section only.

- **A book is called by its own name.** Links were labelled with their host, so every book from one site had the same name; a PDF's own title is used now, with the file at the end of the link as the fallback.
- **The wheel zooms again**, a notch at a time, and panning a magnified page is reachable behind it.
- **A page turn is quicker**, 480ms rather than 700ms, and carries less work on each frame.
- **The book tips away from flat again**, with shift and a drag or the right button.

Three of the four were capabilities the engine replacement had taken away without anyone noticing, which is why `docs/engine-api.md` now records what a reader can do to the stage as well as what the application calls.

**7.2.0** rather than a patch: the title and the tilt are additions, and the served asset list changes with the version.

## Checklist

- [x] `npm run check && npm run lint && npm test` pass locally (160/160)
- [x] Version consistent across `package.json`, `lib/js/app.js`, `sw.js`, the `?v=` strings, `data-zaya-version` and the deploy-guard fixtures
- [x] No code changed in this pull request

## After merging

This wants a signed tag, as the four before it do. Tag pushes are refused from the session that produced this work, so they need your machine:

```
git tag -s v7.2.0 <the merge commit> -m "Zaya 7.2.0"
git push origin v7.2.0
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABXLiVumYcz8fhQVaqBHQ4)_