### PR TITLE
Lay the book down the way a book lies down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Zaya are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Laying the book down works the way a book does.** The first attempt at restoring this let the
+  view swing around the book on two axes, left and right as well as up and down, which is not what
+  a book does and read as an unsteady camera rather than a book on a table. It is one angle on one
+  axis now: the book turns about the horizontal line through its own middle, the far edge receding
+  and the near edge coming forward, exactly as a book is tipped down onto a table. It never swings
+  sideways. The angle is stated the way a reader would think of it — 90 degrees is the book held up
+  facing you, which is how it opens, and it rises from there towards flat. The lens stays on the
+  line through the middle of the pages and looks at them square on; it draws straight back as the
+  book goes down, because the near edge would otherwise run off the sides of the stage, which is
+  stepping back from a table rather than walking around it.
+
 ## [7.2.0] - 2026-09-07
 
 Four things a reader reaches for, three of which the engine replacement had quietly taken away.

--- a/docs/engine-api.md
+++ b/docs/engine-api.md
@@ -252,15 +252,21 @@ contract: the `zoomChange` option fires **once** on each crossing of the fit bou
 once per step; a magnified page is re-rendered at the magnified scale rather than merely
 stretched; and the reader can pan a magnified page and get back to fit.
 
-| `tilt` | getter → `{pitch, yaw, tilted}` | How far the book is tipped away from flat, in radians: `pitch` above or below it, `yaw` to one side. `tilted` is false when it lies flat. | control bar | KEEP |
-| `setTilt(pitch, yaw)` | `(number, number) → tilt` | Tip the book. An engine clamps the angles to what stays readable and returns what it applied, so a caller can follow. | control bar | KEEP |
-| `resetTilt()` | `() → tilt` | Lay it flat again. | control bar | KEEP |
+| `tilt` | getter → `{degrees, tilted}` | How far the book is laid down, in degrees. `90` is the book held up facing the reader, which is how it opens; larger lays it towards a table. `tilted` is false at 90. | control bar | KEEP |
+| `setTilt(degrees)` | `(number) → tilt` | Lay the book down or stand it up. One angle, one axis. An engine clamps it to what stays readable and returns what it applied, so a caller can follow. | control bar | KEEP |
+| `resetTilt()` | `() → tilt` | Stand it back up, facing the reader. | control bar | KEEP |
 
-The reader tips the book by holding shift and dragging, or by dragging with the right button, and
-lays it flat again with shift and a double click. It needs a gesture of its own because an ordinary
-drag anywhere on the stage turns a page — including the space beside the book, which is where a
-reader reaches to flick a corner. An engine that cannot tip a book keeps these members and reports
-a flat one.
+The reader lays the book down by holding shift and dragging up or down, or by dragging with the
+right button, and stands it up again with shift and a double click. It needs a gesture of its own
+because an ordinary drag anywhere on the stage turns a page — including the space beside the book,
+which is where a reader reaches to flick a corner.
+
+**One axis, about the book's own middle.** The book turns the way a book is tipped down onto a
+table: the far edge recedes, the near edge comes forward, and the spine stays where it is. It never
+swings left or right, and the lens never travels around it — it looks at the middle of the pages
+square on, and only draws straight back as the book goes down, because the near edge would
+otherwise run off the sides of the stage. That is the difference between stepping back from a table
+and walking around it. An engine that cannot lay a book down keeps these members and reports 90.
 
 > **Why this is written down.** This capability was lost in 7.0.0 and restored in the release after
 > it. The first version of this contract recorded only `book.stage.orbitControl.enabled` under the
@@ -338,8 +344,8 @@ wheel, panning, and tipping the book.
 | control and the wheel | the same — it is how a trackpad pinch and the keyboard zoom arrive | the same |
 | two fingers apart or together | zooms about their midpoint | the same, and pans with them |
 | double-click or double-tap | zooms in on that point | back to fit |
-| shift and drag, or the right button | tips the book away from flat | the same |
-| shift and double-click | lays a tipped book flat | the same |
+| shift and drag up or down, or the right button | lays the book down towards a table, or stands it up | the same |
+| shift and double-click | stands the book back up, facing the reader | the same |
 | a press on a run of text | selects it, and never turns a page | the same |
 
 Two rules behind the table. A gesture on the book and a gesture beside it do the same thing: the

--- a/engine-next/gestures.js
+++ b/engine-next/gestures.js
@@ -11,10 +11,10 @@
  * | gesture | at rest | zoomed in |
  * | --- | --- | --- |
  * | press and drag | the sheet follows the pointer and settles on release | the page pans |
- * | shift and drag, or the right button | tips the book away from flat | the same |
+ * | shift and drag up or down, or the right button | lays the book down towards a table, or stands it up | the same |
  * | click or tap | turns the side that was tapped | nothing |
  * | double-click, double-tap | zooms in on that point | zooms back out to fit |
- * | shift and double-click | lays a tipped book flat again | the same |
+ * | shift and double-click | stands the book back up, facing the reader | the same |
  * | the wheel | zooms about the pointer | zooms about the pointer, and pans none |
  * | two fingers apart or together | zooms about their midpoint | the same, and pans with them |
  *
@@ -170,8 +170,9 @@ export class Gestures {
     drag.moved = true;
 
     if (drag.orbit && !this.on.isZoomed()) {
+      // Only the up-and-down counts: the book lays down and stands up, it does not swing sideways.
       if (typeof this.on.onOrbit === "function") {
-        this.on.onOrbit(event.clientX - drag.lastX, event.clientY - drag.lastY);
+        this.on.onOrbit(0, event.clientY - drag.lastY);
       }
       drag.lastX = event.clientX;
       drag.lastY = event.clientY;

--- a/engine-next/index.js
+++ b/engine-next/index.js
@@ -131,9 +131,8 @@ export class ZayaBook {
     this.turnToken = 0;
     this.interactive = true;
     this.zoomLevel = 1;
-    // How far the book is tipped away from flat, in radians. Flat until the reader tips it.
-    this.tiltPitch = 0;
-    this.tiltYaw = 0;
+    // Degrees from upright: 90 is the book facing the reader, which is how it opens.
+    this.tiltDegrees = 90;
     this.panX = 0;
     this.panY = 0;
     this.dragTurn = null;
@@ -621,31 +620,33 @@ export class ZayaBook {
   /* ---- tilt ------------------------------------------------------------------------------- */
 
   /**
-   * Tip the book by a drag, in pixels. A drag across the whole stage turns it about as far as it
-   * will go, so the book follows the hand at a rate that suits the size of the window.
+   * Lay the book down, or stand it up, by a drag. Only the up-and-down of the drag counts: the
+   * book turns about one axis, so a hand that wanders sideways does not send it sideways too.
+   * Dragging down lays it towards the table; dragging up brings it back to facing the reader.
    */
   tiltBy(dx, dy) {
-    const perPixel = Math.PI / Math.max(320, this.stage.clientWidth);
-    return this.setTilt(this.tiltPitch + dy * perPixel, this.tiltYaw + dx * perPixel);
+    const perPixel = 90 / Math.max(240, this.stage.clientHeight * 0.6);
+    return this.setTilt(this.tiltDegrees + dy * perPixel);
   }
 
-  /** Set the angle outright. Radians; the renderer clamps them to what stays readable. */
-  setTilt(pitch, yaw) {
+  /**
+   * Set the angle outright.
+   * @param {number} degrees 90 upright and facing the reader, rising towards flat on a table
+   */
+  setTilt(degrees) {
     if (!this.renderer || typeof this.renderer.setTilt !== "function") return this.tilt;
-    const applied = this.renderer.setTilt(pitch, yaw) || { pitch: 0, yaw: 0 };
-    this.tiltPitch = applied.pitch;
-    this.tiltYaw = applied.yaw;
+    this.tiltDegrees = this.renderer.setTilt(degrees) || 90;
     this.announceTilt();
     return this.tilt;
   }
 
-  /** Lay the book flat again. */
+  /** Stand the book back up, facing the reader. */
   resetTilt() {
-    return this.setTilt(0, 0);
+    return this.setTilt(90);
   }
 
   get tilt() {
-    return { pitch: this.tiltPitch, yaw: this.tiltYaw, tilted: !!(this.tiltPitch || this.tiltYaw) };
+    return { degrees: this.tiltDegrees, tilted: this.tiltDegrees !== 90 };
   }
 
   announceTilt() {

--- a/engine-next/renderer-css.js
+++ b/engine-next/renderer-css.js
@@ -36,7 +36,7 @@ export class CssRenderer {
     this.pageH = 1;
     this.frame = 0;
     this.zoom = { level: 1, x: 0, y: 0 };
-    this.tilt = { pitch: 0, yaw: 0 };
+    this.tiltDegrees = 90;
 
     this.spread = element("zn-spread");
     this.left = element("zn-page zn-page-left");
@@ -131,25 +131,25 @@ export class CssRenderer {
   }
 
   /**
-   * Tip the book away from flat. There is no camera here, so the same intention is expressed as a
-   * rotation of the spread in the browser's own perspective: the reader gets the same picture by a
-   * different route, rather than the tilt being a thing only the 3D renderer can do.
+   * Lay the book down. There is no camera here, so the same intention is expressed as a rotation
+   * of the spread in the browser's own perspective: one axis, about the middle of the pages, the
+   * reader getting the same picture by a different route.
+   * @param {number} degrees 90 upright and facing the reader, rising towards flat
    */
-  setTilt(pitch, yaw) {
-    this.tilt = { pitch: pitch || 0, yaw: yaw || 0 };
+  setTilt(degrees) {
+    const wanted = Number.isFinite(degrees) ? degrees : 90;
+    this.tiltDegrees = Math.max(90, Math.min(170, wanted));
     this.applyZoom();
-    return this.tilt;
+    return this.tiltDegrees;
   }
 
   applyZoom() {
     const { level, x, y } = this.zoom;
-    const { pitch, yaw } = this.tilt || { pitch: 0, yaw: 0 };
+    const laid = (this.tiltDegrees || 90) - 90;
     this.spread.style.transformOrigin = "50% 50%";
-    const flat = level === 1 && !x && !y && !pitch && !yaw;
-    // A positive pitch looks down on the book, which is the page leaning away at its top edge.
-    const turn = pitch || yaw
-      ? ` rotateX(${(pitch * 180) / Math.PI}deg) rotateY(${(-yaw * 180) / Math.PI}deg)`
-      : "";
+    const flat = level === 1 && !x && !y && !laid;
+    // The far edge of the page recedes, as it does when a book is tipped down onto a table.
+    const turn = laid ? ` rotateX(${laid}deg)` : "";
     this.spread.style.transform = flat
       ? "" : `translate(${x}px, ${y}px) scale(${level})${turn}`;
   }

--- a/engine-next/renderer-webgl.js
+++ b/engine-next/renderer-webgl.js
@@ -21,11 +21,12 @@ const FOV = 32;
 /** Segments across the sheet. Enough that the curl reads as a curve rather than a fold. */
 const SEGMENTS = 28;
 /*
- * How far the book can be turned away from flat. Far enough to look along the page the way you
- * would tip a real book towards a lamp, and not so far that it is edge-on and unreadable.
+ * How far the book can be laid down, in degrees. 90 is a book held up facing the reader, which is
+ * how it opens; 180 would be flat on a table and edge-on to the lens, so the useful travel stops
+ * short of it. The book turns about its own middle and the lens does not move.
  */
-const MAX_PITCH = (60 * Math.PI) / 180;
-const MAX_YAW = (45 * Math.PI) / 180;
+const TILT_UPRIGHT = 90;
+const TILT_MAX = 160;
 /** How far the paper bulges out of plane, as a fraction of the page width. */
 const CURL = 0.16;
 
@@ -86,8 +87,8 @@ export class WebglRenderer {
 
     this.scene = new THREE.Scene();
     this.camera = new THREE.PerspectiveCamera(FOV, 1, 0.05, 200);
-    // How far the lens has been carried around the book: flat on, until the reader says otherwise.
-    this.tilt = { pitch: 0, yaw: 0 };
+    // Degrees from upright. The book opens facing the reader and stays there until they lay it down.
+    this.tiltDegrees = TILT_UPRIGHT;
     this.setBackground(book.options.backgroundColor);
 
     this.pageW = 0.72;                 // world units; corrected as soon as a page is measured
@@ -285,18 +286,18 @@ export class WebglRenderer {
   }
 
   /**
-   * Carry the lens around the book. Angles are radians and are clamped, so a reader who keeps
-   * dragging stops at a useful angle rather than looking at the spine edge-on.
-   * @param {number} pitch above (positive) or below the book
-   * @param {number} yaw to one side or the other
+   * Lay the book down, or stand it back up. One angle and one axis: the book turns about the
+   * horizontal line through its own middle, the way a book is tipped down onto a table, and the
+   * lens stays where it is, looking at the middle of the pages. Nothing swings around the book.
+   * @param {number} degrees 90 upright and facing the reader, rising towards flat
    */
-  setTilt(pitch, yaw) {
-    this.tilt = {
-      pitch: Math.max(-MAX_PITCH, Math.min(MAX_PITCH, pitch || 0)),
-      yaw: Math.max(-MAX_YAW, Math.min(MAX_YAW, yaw || 0)),
-    };
+  setTilt(degrees) {
+    const wanted = Number.isFinite(degrees) ? degrees : TILT_UPRIGHT;
+    this.tiltDegrees = Math.max(TILT_UPRIGHT, Math.min(TILT_MAX, wanted));
+    // Away from the reader, so the far edge of the page recedes and the near edge comes forward.
+    this.scene.rotation.x = -((this.tiltDegrees - TILT_UPRIGHT) * Math.PI) / 180;
     this.placeCamera();
-    return this.tilt;
+    return this.tiltDegrees;
   }
 
   placeCamera() {
@@ -313,22 +314,15 @@ export class WebglRenderer {
      * over the book rather than sliding the book about. At a pitch and yaw of zero this is exactly
      * the straight-on placement it replaces: (cx, cy, distance / level), looking at (cx, cy, 0).
      */
-    const { pitch, yaw } = this.tilt;
     /*
-     * Tipping the book brings its nearest corner towards the lens, and with a perspective lens that
-     * corner grows and runs off the top or the side of the stage. Backing off by exactly how far
-     * that corner came forward keeps the whole book in view at any angle; at zero tilt it adds
-     * nothing, so a flat book is framed exactly as before.
+     * The lens never swings around the book: it stays on the line through the middle of the pages,
+     * looking at them square on. It does draw straight back as the book is laid down, because the
+     * near edge swings towards it and would otherwise run off the sides of the stage — the same
+     * move as stepping back from a table, not walking around it.
      */
-    const nearer = (this.fit.spreadW / 2) * Math.abs(Math.sin(yaw))
-      + (this.fit.spreadH / 2) * Math.abs(Math.sin(pitch));
-    const radius = (distance + nearer) / level;
-    const cosPitch = Math.cos(pitch);
-    this.camera.position.set(
-      cx + radius * Math.sin(yaw) * cosPitch,
-      cy + radius * Math.sin(pitch),
-      radius * Math.cos(yaw) * cosPitch,
-    );
+    const laid = ((this.tiltDegrees - TILT_UPRIGHT) * Math.PI) / 180;
+    const radius = (distance + (this.fit.spreadH / 2) * Math.sin(laid)) / level;
+    this.camera.position.set(cx, cy, radius);
     this.camera.lookAt(cx, cy, 0);
     this.camera.updateProjectionMatrix();
     this.requestRender();

--- a/lib/js/core/book.js
+++ b/lib/js/core/book.js
@@ -279,19 +279,19 @@
             else b.zoomIn();
         };
         /**
-         * How far the book is tipped away from flat, in radians, and how to tip it. A reader does
-         * this by dragging beside the book; this is here so the interface can offer it too, and so
-         * that it is part of the contract rather than something an engine may quietly drop.
+         * How far the book is laid down, in degrees from upright, and how to lay it down. 90 is
+         * the book facing the reader, which is how it opens. A reader does this by holding shift
+         * and dragging up or down; this is here so the interface can offer it too, and so that it
+         * is part of the contract rather than something an engine may quietly drop.
          */
         Object.defineProperty(self, "tilt", {
             get: () => {
                 const b = book();
                 const t = b && b.tilt;
-                return t ? { pitch: t.pitch, yaw: t.yaw, tilted: !!t.tilted }
-                    : { pitch: 0, yaw: 0, tilted: false };
+                return t ? { degrees: t.degrees, tilted: !!t.tilted } : { degrees: 90, tilted: false };
             }
         });
-        self.setTilt = (pitch, yaw) => { const b = book(); if (b && b.setTilt) b.setTilt(pitch, yaw); return self.tilt; };
+        self.setTilt = (degrees) => { const b = book(); if (b && b.setTilt) b.setTilt(degrees); return self.tilt; };
         self.resetTilt = () => { const b = book(); if (b && b.resetTilt) b.resetTilt(); return self.tilt; };
 
         self.resize = () => { const b = book(); if (b) b.resize(); };

--- a/tests/smoke.spec.mjs
+++ b/tests/smoke.spec.mjs
@@ -161,12 +161,13 @@ test.describe('Tilting the book', () => {
    * Lost in 7.0.0 and restored after it: the reader can tip the book away from flat. Held here
    * rather than only in the engine's own tests, because what matters is that a reader can do it.
    */
-  test('shift and a drag tips it, an ordinary drag still turns the page', async ({ page }) => {
+  test('shift and a drag lays it down, an ordinary drag still turns the page', async ({ page }) => {
     await stubNetwork(page);
     await page.goto('/index.html?pdf=https://example.com/sample.pdf');
     await waitForBook(page);
     const tilt = () => page.evaluate(() => window.ZayaBook.current.tilt);
-    expect(await tilt()).toEqual({ pitch: 0, yaw: 0, tilted: false });
+    // 90 is the book held up facing the reader, which is how it opens.
+    expect(await tilt()).toEqual({ degrees: 90, tilted: false });
 
     const box = await page.locator('#flipbookContainer').boundingBox();
     const y = box.y + box.height / 2;
@@ -177,15 +178,25 @@ test.describe('Tilting the book', () => {
     await page.keyboard.down('Shift');
     await page.mouse.move(box.x + box.width * 0.5, y);
     await page.mouse.down();
-    await page.mouse.move(box.x + box.width * 0.5 + 130, y - 90, { steps: 14 });
+    await page.mouse.move(box.x + box.width * 0.5 + 130, y + 90, { steps: 14 });
     await page.mouse.up();
     await page.keyboard.up('Shift');
     await expect.poll(async () => (await tilt()).tilted, { timeout: 10_000 }).toBe(true);
-    const tipped = await tilt();
-    expect(tipped.yaw).toBeGreaterThan(0);      // dragged to the right
-    expect(tipped.pitch).toBeLessThan(0);       // and upwards
+    const laid = await tilt();
+    // Dragging down lays the book towards the table, and only the up-and-down of the drag counts.
+    expect(laid.degrees).toBeGreaterThan(90);
 
-    // Dragging on the book still turns its pages rather than tipping it.
+    // A drag straight across does not lay it down any further: there is no sideways axis.
+    const before2 = (await tilt()).degrees;
+    await page.keyboard.down('Shift');
+    await page.mouse.move(box.x + box.width * 0.4, y);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width * 0.75, y, { steps: 12 });
+    await page.mouse.up();
+    await page.keyboard.up('Shift');
+    expect((await tilt()).degrees).toBe(before2);
+
+    // Dragging on the book still turns its pages rather than laying it down.
     const before = await activePage(page);
     await page.mouse.move(box.x + box.width * 0.75, y);
     await page.mouse.down();


### PR DESCRIPTION
## Summary

The first restoration of this was wrong in shape, not just in degree. It let the view swing around the book on **two** axes — left and right as well as up and down — which is not what a book does, and read as an unsteady camera rather than a book on a table.

**One angle, one axis.** The book turns about the horizontal line through its own middle: the far edge recedes, the near edge comes forward, the spine stays put. It never swings sideways — a drag that wanders across the stage does not take the book with it, because only the up-and-down of the drag counts.

**Stated the way a reader thinks of it.** The angle is degrees, not radians from some zero: **90 is the book held up facing you**, which is how it opens, rising from there towards flat.

**The lens does not travel.** It stays on the line through the middle of the pages, looking at them square on. It draws *straight back* as the book goes down, because the near edge swings towards it and would otherwise run off the sides of the stage — stepping back from a table, not walking around it.

The engine stops at 160° rather than 180°. At 180° a book is edge-on to a lens that has not moved, which is to say invisible; the travel stops where a page still reads.

## Checked by eye

Rendered at 90, 120 and 150 degrees on a full spread — symmetric, centred, nothing clipped, and it reads as a book laid on a table. That mattered here: the numbers were right in the first version too. Two faults only the pictures showed — the near edge running off the sides at 150°, and the book shrinking and drifting upward when the lens moved — are both fixed.

One thing worth knowing, because it looks like a bug and is not: on the **cover**, the tilted page is not symmetric. The cover sits alone on one half of the spread, so it is off to one side of the lens and foreshortens more on its outer edge. A full spread is symmetric.

## On the old angles

You asked me to check the old implementation's angles. I deliberately have not: the fork is CC BY-NC-ND, and `engine-next/` being demonstrably clean-room is what makes the MIT claim in `docs/THIRD_PARTY_NOTICES.md` and the README true. Reading the deleted engine to copy its numbers would undermine that for a handful of constants. This is built from your description instead — one axis, pivot at the book's centre, 90 upright, camera fixed on the page centre. If the feel is still off, tell me what to change and I will change it; the angle, the limit and the rate are all one-line constants.

## Checklist

- [x] `npm run check && npm run lint && npm test` pass locally (160/160)
- [x] The test now also asserts that a sideways drag changes nothing, which is the bug this fixes
- [x] Both renderers: the plain-DOM one rotates the spread on the same single axis
- [x] `CHANGELOG.md` under Unreleased; `docs/engine-api.md` records the axis, the pivot and what the lens may do

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABXLiVumYcz8fhQVaqBHQ4)_